### PR TITLE
Use HTTP endpoint for ISS telemetry

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,7 +1,7 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
 import ISSGlobe, { TRAIL_POINT_COUNT } from './components/ISSGlobe.jsx';
 
-const API_URL = 'https://api.open-notify.org/iss-now.json';
+const API_URL = 'http://api.open-notify.org/iss-now.json';
 
 const formatCoordinate = (value, type) => {
   if (Number.isNaN(value)) {


### PR DESCRIPTION
## Summary
- update the ISS telemetry API URL to the working HTTP endpoint

## Testing
- npm install *(fails: 403 Forbidden retrieving @vitejs/plugin-react)*

------
https://chatgpt.com/codex/tasks/task_e_68d99f2eb68083319b07450173f07a68