### PR TITLE
Reduce maximum playback speed to 200x

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Visit [http://localhost:5173](http://localhost:5173) once the dev server is runn
 ## Features
 
 - 🚀 **Cupola view** – lock the camera to the ISS with gentle sway (optional via reduced-motion toggle)
-- ⏱️ **Time-lapse playback** – scrub ±12 hours, jump between speeds (1× to 600×), and differentiate live vs simulated sessions
+- ⏱️ **Time-lapse playback** – scrub ±12 hours, jump between speeds (1× to 200×), and differentiate live vs simulated sessions
 - 🌗 **Dynamic terminator shader** – day/night lighting tied to real-time solar position with optional city lights
 - 🌌 **Optional overlays** – toggle global clouds, auroral ovals, and city lights; overlays auto-throttle during high-speed playback
 - 🫧 **Weightlessness feel** – floating HUD cards and particle drift when enabled, paused automatically during heavy interaction
@@ -24,7 +24,7 @@ Visit [http://localhost:5173](http://localhost:5173) once the dev server is runn
 ## Controls & UI
 
 - **View mode panel (left)** – switch between *Orbital Map* (full globe control) and *Cupola View* (ISS first person). Cupola view supports subtle head turns via mouse/touch within ±30°.
-- **Time controls (bottom centre)** – play/pause, speed selection (1×, 10×, 60×, 600×), and a timeline scrubber. Keyboard shortcuts: `Space` toggles play, `←/→` adjust ±10 seconds, `Shift + ←/→` adjust ±5 minutes.
+- **Time controls (bottom centre)** – play/pause, speed selection (1×, 10×, 60×, 200×), and a timeline scrubber. Keyboard shortcuts: `Space` toggles play, `←/→` adjust ±10 seconds, `Shift + ←/→` adjust ±5 minutes.
 - **Toggles (right)** – enable weightlessness, terminator shading, clouds, aurora, city lights, and reduced motion. Weightlessness includes an intensity slider (default 0.4) and respects reduced-motion preferences.
 - **Tooltips** – the first run displays a one-line Cupola tip. Dismissals are stored in `localStorage`.
 
@@ -37,7 +37,7 @@ Visit [http://localhost:5173](http://localhost:5173) once the dev server is runn
 
 - Enable *Reduced Motion* to disable Cupola sway, HUD drift, and weightless particles.
 - Weightlessness automatically pauses while the globe is being manipulated to keep controls precise.
-- High-speed playback (>600×) temporarily hides heavy overlays (clouds, aurora) to maintain smooth frame rates.
+- High-speed playback (>200×) temporarily hides heavy overlays (clouds, aurora) to maintain smooth frame rates.
 
 ## Telemetry & Debugging
 

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -92,7 +92,7 @@ function App() {
 
   const liveBadge = mode === 'live' ? 'Live orbit' : 'Simulated playback';
 
-  const fastOverlaySuspended = mode === 'simulated' && speed >= 600;
+  const fastOverlaySuspended = mode === 'simulated' && speed >= 200;
 
   const allowWeightlessHud = weightlessnessEnabled && !reducedMotion && !isInteracting;
 
@@ -151,7 +151,7 @@ function App() {
     }
     lastTrackUpdateRef.current = now;
 
-    const stepSeconds = speed >= 600 ? 90 : speed >= 60 ? 45 : 15;
+    const stepSeconds = speed >= 200 ? 90 : speed >= 60 ? 45 : 15;
     const trail = buildGroundTrack(satrec, now, 360, stepSeconds);
     const future = fastPlayback ? [] : buildFutureTrack(satrec, now, 30, 30);
     setTrailPoints(trail);

--- a/src/state/timeStore.tsx
+++ b/src/state/timeStore.tsx
@@ -11,7 +11,7 @@ import {
 
 export type TimeMode = 'live' | 'simulated';
 
-export const PLAYBACK_SPEEDS = [1, 10, 60, 600] as const;
+export const PLAYBACK_SPEEDS = [1, 10, 60, 200] as const;
 const HIGH_SPEED_THRESHOLD = 60;
 const HIGH_SPEED_INTERVAL = 200;
 const NORMAL_INTERVAL = 16;


### PR DESCRIPTION
## Summary
- lower the time control speed options so the maximum selectable rate is 200×
- align overlay throttling and ground track stepping thresholds with the new maximum speed
- refresh user-facing documentation to reflect the revised speed cap

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68da56fd8e5483318d30f7dd9e806b58