### PR TITLE
Refactor HUD overlay controls into hamburger menu panel

### DIFF
--- a/src/components/HudMenuPanel.tsx
+++ b/src/components/HudMenuPanel.tsx
@@ -1,0 +1,245 @@
+import { useEffect, useMemo, useRef } from 'react';
+
+type OverlayOptionKey =
+  | 'weightlessness'
+  | 'terminator'
+  | 'clouds'
+  | 'aurora'
+  | 'cityLights'
+  | 'reducedMotion';
+
+type OverlayOptions = Record<OverlayOptionKey, boolean>;
+
+interface HudMenuPanelProps {
+  open: boolean;
+  onClose: () => void;
+  options: OverlayOptions;
+  toggleOption: (key: OverlayOptionKey) => void;
+  weightlessnessIntensity: number;
+  onWeightlessnessIntensityChange: (value: number) => void;
+  fastOverlaySuspended: boolean;
+  reducedMotion: boolean;
+}
+
+const FOCUSABLE_SELECTORS =
+  'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])';
+
+const HudMenuPanel = ({
+  open,
+  onClose,
+  options,
+  toggleOption,
+  weightlessnessIntensity,
+  onWeightlessnessIntensityChange,
+  fastOverlaySuspended,
+  reducedMotion,
+}: HudMenuPanelProps) => {
+  const panelRef = useRef<HTMLDivElement | null>(null);
+  const previouslyFocusedElementRef = useRef<HTMLElement | null>(null);
+
+  useEffect(() => {
+    if (!open) {
+      return undefined;
+    }
+
+    previouslyFocusedElementRef.current = document.activeElement as HTMLElement | null;
+
+    const focusPanel = () => {
+      const panel = panelRef.current;
+      if (!panel) return;
+      const focusable = panel.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTORS);
+      const firstFocusable = focusable[0];
+      if (firstFocusable) {
+        firstFocusable.focus();
+      } else {
+        panel.focus();
+      }
+    };
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        event.preventDefault();
+        onClose();
+        return;
+      }
+
+      if (event.key === 'Tab') {
+        const panel = panelRef.current;
+        if (!panel) {
+          return;
+        }
+        const focusable = Array.from(
+          panel.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTORS)
+        ).filter((element) => !element.hasAttribute('disabled'));
+        if (focusable.length === 0) {
+          event.preventDefault();
+          panel.focus();
+          return;
+        }
+        const first = focusable[0];
+        const last = focusable[focusable.length - 1];
+        const current = document.activeElement as HTMLElement | null;
+        if (event.shiftKey) {
+          if (current === first || !panel.contains(current)) {
+            event.preventDefault();
+            last.focus();
+          }
+        } else if (current === last || !panel.contains(current)) {
+          event.preventDefault();
+          first.focus();
+        }
+      }
+    };
+
+    const previousOverflow = document.body.style.overflow;
+    document.body.style.overflow = 'hidden';
+    focusPanel();
+    document.addEventListener('keydown', handleKeyDown);
+
+    return () => {
+      document.body.style.overflow = previousOverflow;
+      document.removeEventListener('keydown', handleKeyDown);
+      previouslyFocusedElementRef.current?.focus?.();
+    };
+  }, [open, onClose]);
+
+  const overlayOptions = useMemo(
+    () => [
+      { key: 'terminator' as const, label: 'Terminator', description: 'Show the day/night boundary.' },
+      {
+        key: 'clouds' as const,
+        label: 'Clouds',
+        description: 'Render real-time global cloud coverage.',
+        disabled: fastOverlaySuspended,
+      },
+      {
+        key: 'aurora' as const,
+        label: 'Aurora',
+        description: 'Visualize auroral activity across the poles.',
+        disabled: fastOverlaySuspended,
+      },
+      { key: 'cityLights' as const, label: 'City Lights', description: 'Highlight major metropolitan areas.' },
+    ],
+    [fastOverlaySuspended]
+  );
+
+  if (!open) {
+    return null;
+  }
+
+  return (
+    <div className="hud-menu-backdrop" role="presentation" onClick={onClose}>
+      <div
+        ref={panelRef}
+        className="hud-menu-panel"
+        role="dialog"
+        id="hud-menu-panel"
+        aria-modal="true"
+        aria-labelledby="hud-menu-title"
+        tabIndex={-1}
+        onClick={(event) => event.stopPropagation()}
+      >
+        <header className="hud-menu-header">
+          <h2 id="hud-menu-title">HUD &amp; Overlay Controls</h2>
+          <button
+            type="button"
+            className="hud-menu-close"
+            onClick={onClose}
+            aria-label="Close HUD menu"
+          >
+            ×
+          </button>
+        </header>
+
+        <section className="hud-menu-section" aria-labelledby="hud-menu-experience">
+          <h3 id="hud-menu-experience">Visual Experience</h3>
+          <label className={`hud-menu-toggle${reducedMotion ? ' is-disabled' : ''}`}>
+            <input
+              type="checkbox"
+              checked={options.weightlessness}
+              onChange={() => toggleOption('weightlessness')}
+              disabled={reducedMotion}
+            />
+            <span>
+              <span className="hud-menu-toggle-label">Weightlessness</span>
+              <span className="hud-menu-toggle-description">
+                Enable gentle cockpit sway for the Cupola view.
+              </span>
+            </span>
+          </label>
+          <label className="hud-menu-slider">
+            <span>Drift intensity</span>
+            <input
+              type="range"
+              min={0}
+              max={1}
+              step={0.05}
+              value={weightlessnessIntensity}
+              onChange={(event) => onWeightlessnessIntensityChange(Number(event.target.value))}
+              disabled={!options.weightlessness || reducedMotion}
+            />
+          </label>
+          {reducedMotion && (
+            <p className="hud-menu-note">
+              Weightlessness is disabled while Reduced Motion is active.
+            </p>
+          )}
+        </section>
+
+        <section className="hud-menu-section" aria-labelledby="hud-menu-overlays">
+          <h3 id="hud-menu-overlays">Earth overlays</h3>
+          <div className="hud-menu-grid">
+            {overlayOptions.map(({ key, label, description, disabled }) => (
+              <label
+                key={key}
+                className={`hud-menu-toggle${disabled ? ' is-disabled' : ''}`}
+                aria-disabled={disabled || undefined}
+              >
+                <input
+                  type="checkbox"
+                  checked={options[key]}
+                  onChange={() => toggleOption(key)}
+                  disabled={disabled}
+                />
+                <span>
+                  <span className="hud-menu-toggle-label">{label}</span>
+                  <span className="hud-menu-toggle-description">{description}</span>
+                </span>
+              </label>
+            ))}
+          </div>
+          {fastOverlaySuspended && (
+            <p className="hud-menu-note">
+              Some overlays are temporarily paused at very high playback speeds to keep the simulation responsive.
+            </p>
+          )}
+        </section>
+
+        <section className="hud-menu-section" aria-labelledby="hud-menu-accessibility">
+          <h3 id="hud-menu-accessibility">Motion &amp; accessibility</h3>
+          <label className="hud-menu-toggle">
+            <input
+              type="checkbox"
+              checked={options.reducedMotion}
+              onChange={() => toggleOption('reducedMotion')}
+            />
+            <span>
+              <span className="hud-menu-toggle-label">Reduced Motion</span>
+              <span className="hud-menu-toggle-description">
+                Simplify animations and disable weightlessness drift.
+              </span>
+            </span>
+          </label>
+        </section>
+
+        <div className="hud-menu-actions">
+          <button type="button" onClick={onClose} className="hud-menu-primary">
+            Close
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default HudMenuPanel;

--- a/src/styles/hud-menu.css
+++ b/src/styles/hud-menu.css
@@ -1,0 +1,208 @@
+.hud-menu-backdrop {
+  position: fixed;
+  inset: 0;
+  display: flex;
+  justify-content: flex-end;
+  align-items: stretch;
+  background: rgba(2, 6, 23, 0.45);
+  backdrop-filter: blur(10px);
+  z-index: 60;
+  padding: 1.5rem;
+}
+
+.hud-menu-panel {
+  position: relative;
+  width: min(360px, 100%);
+  max-height: calc(100vh - 3rem);
+  overflow-y: auto;
+  border-radius: 24px 0 0 24px;
+  border: 1px solid rgba(148, 163, 184, 0.18);
+  background: linear-gradient(160deg, rgba(15, 23, 42, 0.95), rgba(8, 14, 26, 0.92));
+  box-shadow: 0 30px 80px -30px rgba(56, 189, 248, 0.45);
+  color: #e2e8f0;
+  padding: 2rem 2rem 1.75rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+  animation: hud-menu-slide 220ms ease-out;
+}
+
+.hud-menu-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.hud-menu-header h2 {
+  font-size: 1.1rem;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: #7dd3fc;
+}
+
+.hud-menu-close {
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  background: rgba(15, 23, 42, 0.6);
+  color: #cbd5f5;
+  border-radius: 9999px;
+  width: 2.25rem;
+  height: 2.25rem;
+  font-size: 1.25rem;
+  line-height: 1;
+  cursor: pointer;
+  transition: border-color 120ms ease, color 120ms ease;
+}
+
+.hud-menu-close:hover,
+.hud-menu-close:focus-visible {
+  border-color: rgba(125, 211, 252, 0.65);
+  color: #f8fafc;
+  outline: none;
+}
+
+.hud-menu-section {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.hud-menu-section h3 {
+  font-size: 0.85rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.2em;
+  color: rgba(148, 163, 184, 0.9);
+}
+
+.hud-menu-toggle {
+  display: flex;
+  gap: 0.75rem;
+  align-items: center;
+  padding: 0.75rem 0.85rem;
+  border-radius: 16px;
+  background: rgba(15, 23, 42, 0.6);
+  border: 1px solid rgba(100, 116, 139, 0.35);
+  cursor: pointer;
+  transition: border-color 150ms ease, background 150ms ease;
+}
+
+.hud-menu-toggle input[type='checkbox'] {
+  width: 1.1rem;
+  height: 1.1rem;
+  border-radius: 0.4rem;
+  accent-color: #38bdf8;
+}
+
+.hud-menu-toggle:hover,
+.hud-menu-toggle:focus-within {
+  border-color: rgba(125, 211, 252, 0.7);
+  background: rgba(30, 41, 59, 0.8);
+}
+
+.hud-menu-toggle span {
+  display: flex;
+  flex-direction: column;
+  gap: 0.15rem;
+}
+
+.hud-menu-toggle-label {
+  font-size: 0.95rem;
+  font-weight: 600;
+  color: #f8fafc;
+}
+
+.hud-menu-toggle-description {
+  font-size: 0.75rem;
+  color: rgba(203, 213, 225, 0.8);
+}
+
+.hud-menu-toggle.is-disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.hud-menu-toggle.is-disabled:hover,
+.hud-menu-toggle.is-disabled:focus-within {
+  border-color: rgba(100, 116, 139, 0.35);
+  background: rgba(15, 23, 42, 0.6);
+}
+
+.hud-menu-slider {
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+  font-size: 0.8rem;
+  color: rgba(203, 213, 225, 0.9);
+  padding: 0 0.25rem;
+}
+
+.hud-menu-slider input[type='range'] {
+  width: 100%;
+  accent-color: #38bdf8;
+}
+
+.hud-menu-grid {
+  display: grid;
+  gap: 0.75rem;
+}
+
+.hud-menu-note {
+  font-size: 0.75rem;
+  color: rgba(250, 204, 21, 0.8);
+  background: rgba(250, 204, 21, 0.1);
+  border: 1px solid rgba(250, 204, 21, 0.25);
+  border-radius: 14px;
+  padding: 0.65rem 0.8rem;
+  line-height: 1.4;
+}
+
+.hud-menu-actions {
+  margin-top: auto;
+  display: flex;
+  justify-content: flex-end;
+}
+
+.hud-menu-primary {
+  border-radius: 9999px;
+  border: 1px solid rgba(148, 163, 184, 0.35);
+  background: rgba(30, 41, 59, 0.85);
+  color: #f8fafc;
+  font-size: 0.85rem;
+  font-weight: 600;
+  padding: 0.6rem 1.5rem;
+  cursor: pointer;
+  transition: border-color 150ms ease, background 150ms ease, color 150ms ease;
+}
+
+.hud-menu-primary:hover,
+.hud-menu-primary:focus-visible {
+  border-color: rgba(125, 211, 252, 0.7);
+  background: rgba(56, 189, 248, 0.2);
+  color: #e0f2fe;
+  outline: none;
+}
+
+@media (max-width: 640px) {
+  .hud-menu-backdrop {
+    padding: 1rem;
+  }
+
+  .hud-menu-panel {
+    border-radius: 24px;
+    width: 100%;
+    max-height: calc(100vh - 2rem);
+  }
+}
+
+@keyframes hud-menu-slide {
+  from {
+    transform: translateX(20px);
+    opacity: 0;
+  }
+  to {
+    transform: translateX(0);
+    opacity: 1;
+  }
+}


### PR DESCRIPTION
## Summary
- remove overlay checkboxes from the time bar and point users to the top-right menu
- add an accessible hamburger-triggered HUD menu panel that manages overlay toggles and weightlessness intensity
- style the slide-out with glassmorphism treatment matching the rest of the HUD

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dab363ef088331931abfea26674a0b