### PR TITLE
Redesign header layout and remove footer hint

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -272,26 +272,47 @@ function App() {
 
   return (
     <div className={uiClassName}>
-      <header className="border-b border-slate-800/60 bg-slate-950/70 backdrop-blur">
-        <div className="mx-auto flex w-full max-w-6xl flex-wrap items-center justify-between gap-3 px-6 py-5">
-          <h1 className="text-xl font-semibold uppercase tracking-[0.25em] text-sky-300 sm:text-2xl">
-            Cupola Explorer – Astronaut Edition
-          </h1>
-          <div className="flex items-center gap-3 text-xs text-slate-400">
-            <span className="rounded-full border border-slate-700/60 px-3 py-1 uppercase tracking-[0.3em] text-slate-300">
-              {liveBadge}
-            </span>
-            <span>Orbital data via CelesTrak • Time synced in-app</span>
+      <header className="header-bar">
+        <div className="mx-auto flex w-full max-w-6xl items-center gap-6 px-6 py-4">
+          <div className="flex min-w-0 flex-col text-left">
+            <h1 className="text-lg font-semibold uppercase tracking-[0.4em] text-sky-100 sm:text-2xl">
+              Cupola Explorer
+            </h1>
+            <p className="mt-1 text-xs uppercase tracking-[0.55em] text-sky-400">
+              Astronaut Edition
+            </p>
+          </div>
+          <div className="flex flex-1 items-center justify-center">
+            <div className="flex flex-wrap items-center justify-center gap-3 text-[0.75rem] text-slate-300 sm:text-xs">
+              <span className="rounded-full border border-sky-500/50 bg-sky-900/40 px-4 py-1 text-[0.7rem] font-semibold uppercase tracking-[0.35em] text-sky-200 shadow-[0_0_25px_rgba(56,189,248,0.25)]">
+                {liveBadge}
+              </span>
+              <span className="hidden text-slate-400 sm:inline">Orbital data via CelesTrak • Time synced in-app</span>
+            </div>
+          </div>
+          <div className="flex items-center justify-end">
             <button
               type="button"
-              className="rounded-xl border border-slate-700/60 bg-slate-900/60 px-3 py-2 text-base text-slate-200 transition hover:border-sky-400/70 hover:text-sky-200 focus-visible:outline focus-visible:outline-2 focus-visible:outline-sky-400"
+              className="rounded-xl border border-slate-800/60 bg-slate-900/60 p-2 text-slate-200 transition hover:border-sky-400/70 hover:bg-slate-900/80 hover:text-sky-200 focus-visible:outline focus-visible:outline-2 focus-visible:outline-sky-400"
               aria-haspopup="dialog"
               aria-expanded={hudMenuOpen}
               aria-controls="hud-menu-panel"
               aria-label={hudMenuOpen ? 'Close HUD menu' : 'Open HUD menu'}
               onClick={() => setHudMenuOpen((value) => !value)}
             >
-              ☰
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                viewBox="0 0 24 24"
+                className="h-5 w-5"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="1.8"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                aria-hidden="true"
+              >
+                <path d="M4 6h16M4 12h16M4 18h16" />
+              </svg>
             </button>
           </div>
         </div>
@@ -405,11 +426,8 @@ function App() {
                 <TimeControls onSeek={onSeek} />
               </div>
 
-              <div className="hud-panel flex max-w-sm flex-col gap-3 rounded-3xl border border-slate-800/60 bg-slate-900/80 px-5 py-4 text-xs text-slate-300">
-                <p className="leading-relaxed text-slate-400">
-                  Use the top-right menu to adjust overlays and accessibility settings.
-                </p>
-                {tooltipVisible ? (
+              {tooltipVisible ? (
+                <div className="hud-panel flex max-w-sm flex-col gap-3 rounded-3xl border border-slate-800/60 bg-slate-900/80 px-5 py-4 text-xs text-slate-300">
                   <div className="flex items-start gap-3 text-slate-300">
                     <span className="mt-1 text-sky-300">ⓘ</span>
                     <p className="flex-1 leading-relaxed">{tooltipContent}</p>
@@ -422,8 +440,8 @@ function App() {
                       ×
                     </button>
                   </div>
-                ) : null}
-              </div>
+                </div>
+              ) : null}
             </div>
           </div>
         </div>

--- a/src/index.css
+++ b/src/index.css
@@ -44,6 +44,12 @@ a {
 }
 
 @layer components {
+  .header-bar {
+    @apply relative z-40 border-b border-slate-800/60 backdrop-blur;
+    background: linear-gradient(180deg, rgba(2, 6, 23, 0.9) 0%, rgba(2, 6, 23, 0.65) 100%);
+    box-shadow: 0 18px 45px rgba(15, 23, 42, 0.35);
+  }
+
   .hud-panel {
     @apply pointer-events-auto relative z-10;
   }


### PR DESCRIPTION
## Summary
- restructure the HUD header into a flex layout with separated title, status badge, and right-aligned menu button
- add a gradient and subtle shadow to the header bar to match the existing HUD styling
- remove the persistent footer hint while keeping the contextual tooltip panel conditional on visibility

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dab7c2d648833195e884e5f70b7153