### PR TITLE
Fix education tab reset in HUD panel

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -258,6 +258,10 @@ function App() {
     ]
   );
 
+  const closeHudMenu = useCallback(() => {
+    setHudMenuOpen(false);
+  }, []);
+
   const toggleOverlayOption = useCallback(
     (key) => {
       switch (key) {
@@ -500,7 +504,7 @@ function App() {
       </main>
       <HudMenuPanel
         open={hudMenuOpen}
-        onClose={() => setHudMenuOpen(false)}
+        onClose={closeHudMenu}
         options={overlayOptions}
         toggleOption={toggleOverlayOption}
         weightlessnessIntensity={weightlessnessIntensity}


### PR DESCRIPTION
## Summary
- memoize the HUD menu close handler so the education tab state is preserved
- pass the stable handler into the HUD menu to keep the selected tab active while open

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dfabd8dae08331b6b19e516efe64f7