### PR TITLE
Auto-close education panel after fast timeline demo

### DIFF
--- a/src/components/EducationModule.tsx
+++ b/src/components/EducationModule.tsx
@@ -13,6 +13,7 @@ interface QuizQuestion {
 interface EducationModuleProps {
   issSpeed: number;
   onFastTimeline: (speedMultiplier?: number) => void;
+  onCloseMenu: () => void;
 }
 
 const ALTITUDE_ESTIMATE_KM = 420;
@@ -53,7 +54,7 @@ const lessonCards: Array<{
 const formatNumber = (value: number, fractionDigits: number) =>
   Number.isFinite(value) ? value.toLocaleString(undefined, { maximumFractionDigits: fractionDigits }) : '—';
 
-const EducationModule = ({ issSpeed, onFastTimeline }: EducationModuleProps) => {
+const EducationModule = ({ issSpeed, onFastTimeline, onCloseMenu }: EducationModuleProps) => {
   const [activeLesson, setActiveLesson] = useState<LessonKey | null>(null);
   const [speedUnits, setSpeedUnits] = useState<'kmh' | 'mph' | 'kms'>('kmh');
   const [quizIndex, setQuizIndex] = useState(0);
@@ -229,7 +230,11 @@ const EducationModule = ({ issSpeed, onFastTimeline }: EducationModuleProps) => 
         </div>
         <button
           type="button"
-          onClick={() => triggerTimelineDemo(demoSpeed)}
+          onClick={() => {
+            triggerTimelineDemo(demoSpeed);
+            setActiveLesson(null);
+            onCloseMenu();
+          }}
           className="mt-3 inline-flex items-center gap-2 rounded-lg border border-amber-400/70 bg-amber-500/20 px-3 py-2 text-xs font-semibold uppercase tracking-[0.3em] text-amber-100 transition hover:border-amber-300/70"
         >
           ▶ Fast timeline demo

--- a/src/components/HudMenuPanel.tsx
+++ b/src/components/HudMenuPanel.tsx
@@ -282,7 +282,11 @@ const HudMenuPanel = ({
           hidden={activeTab !== 'education'}
           className="hud-menu-tabpanel"
         >
-          <EducationModule issSpeed={issSpeed} onFastTimeline={onFastTimeline} />
+          <EducationModule
+            issSpeed={issSpeed}
+            onFastTimeline={onFastTimeline}
+            onCloseMenu={onClose}
+          />
         </div>
 
         <div className="hud-menu-actions">


### PR DESCRIPTION
## Summary
- allow the EducationModule to receive an onCloseMenu callback
- reset the active lesson and close the HUD when the fast timeline demo launches
- wire HudMenuPanel to pass its close handler through to the education module

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dfae93371883319edb0bcecacbf51f