### PR TITLE
Refactor EducationPage header layout

### DIFF
--- a/src/pages/EducationPage.tsx
+++ b/src/pages/EducationPage.tsx
@@ -21,21 +21,22 @@ const EducationPage = () => {
   return (
     <div className="education-page flex min-h-screen flex-col bg-gradient-to-b from-slate-950 via-slate-950 to-slate-900 text-sky-100">
       <header className="header-bar">
-        <div className="mx-auto flex w-full max-w-5xl items-center gap-4 px-6 py-4">
+        <div className="mx-auto flex w-full max-w-5xl items-center justify-between px-6 py-4">
           <div className="flex min-w-0 flex-col text-left">
             <h1 className="text-lg font-semibold uppercase tracking-[0.4em] text-sky-100 sm:text-2xl">Cupola Explorer</h1>
             <p className="mt-1 text-xs uppercase tracking-[0.55em] text-sky-400">Astronaut Edition</p>
           </div>
-          <div className="hidden flex-1 items-center justify-center text-xs text-slate-300 sm:flex">
-            <span className="rounded-full border border-sky-500/40 bg-sky-900/40 px-4 py-1 text-[0.7rem] font-semibold uppercase tracking-[0.35em] text-sky-200">
-              Education Mission Briefing
-            </span>
-          </div>
-          <div className="ml-auto flex items-center gap-3">
+          <div className="flex items-center gap-3">
             <button
               type="button"
               onClick={handleBackToExplorer}
-              aria-label="Return to Explorer"
+              className="rounded-xl border border-sky-500/40 bg-sky-500/10 px-4 py-2 text-xs font-semibold uppercase tracking-[0.3em] text-sky-100 transition hover:border-sky-400/70 hover:bg-sky-500/20"
+            >
+              ⬅ Back to Explorer
+            </button>
+            <button
+              type="button"
+              aria-label="Open navigation menu"
               className="rounded-xl border border-slate-800/60 bg-slate-900/60 p-2 text-slate-200 transition hover:border-sky-400/70 hover:bg-slate-900/80 hover:text-sky-200 focus-visible:outline focus-visible:outline-2 focus-visible:outline-sky-400"
             >
               <svg
@@ -51,13 +52,6 @@ const EducationPage = () => {
               >
                 <path d="M4 6h16M4 12h16M4 18h16" />
               </svg>
-            </button>
-            <button
-              type="button"
-              onClick={handleBackToExplorer}
-              className="rounded-xl border border-sky-500/40 bg-sky-500/10 px-4 py-2 text-xs font-semibold uppercase tracking-[0.3em] text-sky-100 transition hover:border-sky-400/70 hover:bg-sky-500/20"
-            >
-              ⬅ Back to Explorer
             </button>
           </div>
         </div>


### PR DESCRIPTION
## Summary
- remove the Education Mission Briefing callout from the education header
- reorganize the header layout so the title stays left-aligned and the controls align to the right

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e147fad02483318eda059fd4d44129