### PR TITLE
Match Explorer education button styling

### DIFF
--- a/src/pages/Explorer.jsx
+++ b/src/pages/Explorer.jsx
@@ -291,7 +291,7 @@ function Explorer() {
             <button
               type="button"
               onClick={() => navigate('/education')}
-              className="ml-2 rounded-md bg-sky-600 px-3 py-1 text-sm font-medium text-white transition hover:bg-sky-700"
+              className="rounded-xl border border-sky-500/40 bg-sky-500/10 px-4 py-2 text-xs font-semibold uppercase tracking-[0.3em] text-sky-100 transition hover:border-sky-400/70 hover:bg-sky-500/20"
             >
               Go to Education
             </button>


### PR DESCRIPTION
## Summary
- align the Explorer header "Go to Education" button styling with the Education page back button for consistency

## Testing
- npm run dev -- --host 0.0.0.0 --port 4173 (manually verified button styles)


------
https://chatgpt.com/codex/tasks/task_e_68e14b1af4d8833198568f81bec925de