### PR TITLE
Refine orbital fallback UX

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,10 +1,12 @@
 import { BrowserRouter, Route, Routes } from 'react-router-dom';
 import Explorer from './pages/Explorer.jsx';
 import EducationPage from './pages/EducationPage.tsx';
+import ToastHost from './ui/ToastHost.tsx';
 
 function App() {
   return (
     <BrowserRouter>
+      <ToastHost />
       <Routes>
         <Route path="/" element={<Explorer />} />
         <Route path="/education" element={<EducationPage />} />

--- a/src/data/orbitService.ts
+++ b/src/data/orbitService.ts
@@ -1,0 +1,165 @@
+import { toastOnce, resetToastKey } from '../ui/toast';
+
+export type OrbitStatus = {
+  status: 'fresh' | 'cached' | 'stale';
+  updatedAt?: number;
+};
+
+export type StoredTle = {
+  line1: string;
+  line2: string;
+  t: number;
+};
+
+const TLE_STORAGE_KEY = 'cupola-iss-tle';
+const MAX_STALENESS_MS = 6 * 60 * 60 * 1000;
+const RETRY_SCHEDULE = [2, 5, 15, 60, 180, 600].map((seconds) => seconds * 1000);
+
+const status: OrbitStatus = { status: 'fresh', updatedAt: undefined };
+let retryIndex = 0;
+let inFlight = false;
+let warnedThisEpisode = false;
+
+status.updatedAt = readCachedTle()?.t ?? status.updatedAt;
+
+function dispatchStatus() {
+  if (typeof window === 'undefined') {
+    return;
+  }
+  window.dispatchEvent(
+    new CustomEvent<OrbitStatus>('orbit:status', {
+      detail: { ...status },
+    })
+  );
+}
+
+function updateStatus(next: OrbitStatus) {
+  status.status = next.status;
+  status.updatedAt = next.updatedAt;
+  dispatchStatus();
+}
+
+function readCachedTle(): StoredTle | null {
+  if (typeof window === 'undefined') {
+    return null;
+  }
+  try {
+    const raw = window.localStorage.getItem(TLE_STORAGE_KEY);
+    if (!raw) return null;
+    const parsed = JSON.parse(raw) as Partial<StoredTle>;
+    if (typeof parsed?.line1 === 'string' && typeof parsed?.line2 === 'string' && typeof parsed?.t === 'number') {
+      return { line1: parsed.line1, line2: parsed.line2, t: parsed.t };
+    }
+  } catch (error) {
+    console.warn('[orbit] unable to parse cached TLE', error);
+  }
+  return null;
+}
+
+function persistTle(record: StoredTle) {
+  if (typeof window === 'undefined') {
+    return;
+  }
+  window.localStorage.setItem(TLE_STORAGE_KEY, JSON.stringify(record));
+}
+
+function nextRetryDelay() {
+  const delay = RETRY_SCHEDULE[Math.min(retryIndex, RETRY_SCHEDULE.length - 1)];
+  if (retryIndex < RETRY_SCHEDULE.length - 1) {
+    retryIndex += 1;
+  }
+  return delay;
+}
+
+async function fetchNetworkTle(): Promise<{ line1: string; line2: string }> {
+  const response = await fetch(
+    'https://celestrak.org/NORAD/elements/gp.php?CATNR=25544&FORMAT=TLE',
+    { cache: 'no-store' }
+  );
+  if (!response.ok) {
+    throw new Error(`Failed to fetch ISS TLE: ${response.status} ${response.statusText}`);
+  }
+  const text = await response.text();
+  const lines = text
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter((line) => line.length > 0);
+  const line1 = lines.find((value) => value.startsWith('1 '));
+  const line2 = lines.find((value) => value.startsWith('2 '));
+  if (!line1 || !line2) {
+    throw new Error('Received malformed ISS TLE');
+  }
+  return { line1, line2 };
+}
+
+export function getOrbitStatus(): OrbitStatus {
+  return { ...status };
+}
+
+export { status as orbitStatus };
+
+export function loadCachedTLE(): StoredTle | null {
+  return readCachedTle();
+}
+
+export async function fetchTLE(): Promise<StoredTle> {
+  const tle = await fetchNetworkTle();
+  const record: StoredTle = { ...tle, t: Date.now() };
+  persistTle(record);
+  retryIndex = 0;
+  warnedThisEpisode = false;
+  resetToastKey('tle-cached');
+  updateStatus({ status: 'fresh', updatedAt: record.t });
+  return record;
+}
+
+export async function ensureTLEFresh(): Promise<void> {
+  if (inFlight) {
+    return;
+  }
+  if (typeof window === 'undefined') {
+    return;
+  }
+  inFlight = true;
+  try {
+    await fetchTLE();
+    inFlight = false;
+  } catch (error) {
+    const cached = loadCachedTLE();
+    if (cached) {
+      const age = Date.now() - cached.t;
+      const isStale = age > MAX_STALENESS_MS;
+      const message = isStale
+        ? 'Orbital updates unavailable. Showing last known orbit (refreshing in background)…'
+        : 'Using cached orbital data while updates retry in the background.';
+      const tone = isStale ? 'warning' : 'info';
+      if (!warnedThisEpisode) {
+        const logMessage = isStale
+          ? '[orbit] cached ISS TLE is stale; using last known values.'
+          : '[orbit] using cached ISS TLE while updates retry.';
+        console.warn(logMessage, error);
+        warnedThisEpisode = true;
+      }
+      updateStatus({ status: isStale ? 'stale' : 'cached', updatedAt: cached.t });
+      toastOnce('tle-cached', message, {
+        type: tone,
+        timeoutMs: isStale ? 6000 : 5000,
+      });
+    } else {
+      if (!warnedThisEpisode) {
+        console.error('[orbit] no cached TLE available after fetch failure.', error);
+        warnedThisEpisode = true;
+      }
+      updateStatus({ status: 'stale', updatedAt: undefined });
+      toastOnce('tle-cached', 'No orbital data available. Retrying…', {
+        type: 'error',
+        timeoutMs: 6000,
+      });
+    }
+    const delay = nextRetryDelay();
+    window.setTimeout(() => {
+      inFlight = false;
+      ensureTLEFresh();
+    }, delay);
+  }
+}

--- a/src/ui/OrbitBanner.tsx
+++ b/src/ui/OrbitBanner.tsx
@@ -1,0 +1,38 @@
+import { useEffect, useState } from 'react';
+import type { OrbitStatus } from '../data/orbitService';
+import { getOrbitStatus } from '../data/orbitService';
+
+export default function OrbitBanner() {
+  const [status, setStatus] = useState<OrbitStatus>(() => getOrbitStatus());
+
+  useEffect(() => {
+    const handleStatus = (event: Event) => {
+      const detail = (event as CustomEvent<OrbitStatus>).detail;
+      if (!detail) return;
+      setStatus(detail);
+    };
+    window.addEventListener('orbit:status', handleStatus);
+    return () => window.removeEventListener('orbit:status', handleStatus);
+  }, []);
+
+  if (status.status === 'fresh') {
+    return null;
+  }
+
+  const baseClass =
+    'w-full rounded-b-3xl border-t px-3 py-2 text-center text-xs font-semibold uppercase tracking-[0.3em] backdrop-blur sm:px-4 sm:py-3 sm:text-sm';
+
+  if (status.status === 'cached') {
+    return (
+      <div className={`${baseClass} border-sky-500/70 bg-sky-900/80 text-sky-100`}>
+        Using cached orbital data while updates retry in the background.
+      </div>
+    );
+  }
+
+  return (
+    <div className={`${baseClass} border-amber-500/70 bg-amber-900/80 text-amber-100`}>
+      Orbital data is stale. Showing last known orbit and retrying updates…
+    </div>
+  );
+}

--- a/src/ui/ToastHost.tsx
+++ b/src/ui/ToastHost.tsx
@@ -1,0 +1,71 @@
+import { useEffect, useState } from 'react';
+
+export type ToastPayload = {
+  key: string;
+  message: string;
+  type?: 'info' | 'warning' | 'error';
+  timeoutMs?: number;
+};
+
+type ActiveToast = ToastPayload & { createdAt: number };
+
+export default function ToastHost() {
+  const [toasts, setToasts] = useState<ActiveToast[]>([]);
+
+  useEffect(() => {
+    const handleToast = (event: Event) => {
+      const detail = (event as CustomEvent<ToastPayload>).detail;
+      if (!detail) return;
+      const timeoutMs = detail.timeoutMs ?? 5000;
+      const toast: ActiveToast = { ...detail, timeoutMs, createdAt: Date.now() };
+      setToasts((current) => {
+        const existing = current.find((item) => item.key === toast.key);
+        if (existing) {
+          return current.map((item) => (item.key === toast.key ? toast : item));
+        }
+        return [...current, toast];
+      });
+      window.setTimeout(() => {
+        setToasts((current) => current.filter((item) => item.key !== toast.key));
+      }, timeoutMs);
+    };
+
+    window.addEventListener('app:toast', handleToast);
+    return () => {
+      window.removeEventListener('app:toast', handleToast);
+    };
+  }, []);
+
+  if (toasts.length === 0) return null;
+
+  return (
+    <div className="pointer-events-none fixed left-4 bottom-4 z-[60] flex w-full max-w-sm flex-col gap-3 sm:max-w-md">
+      {toasts.map((toast) => {
+        const tone =
+          toast.type === 'warning'
+            ? 'border-amber-400/80 bg-amber-900/80 text-amber-100'
+            : toast.type === 'error'
+              ? 'border-rose-400/80 bg-rose-900/80 text-rose-100'
+              : 'border-sky-400/80 bg-sky-900/80 text-sky-100';
+        return (
+          <div
+            key={toast.key}
+            className={`pointer-events-auto flex items-start gap-3 rounded-2xl border px-4 py-3 text-sm shadow-xl backdrop-blur-md transition ${tone}`}
+            role="status"
+            aria-live="assertive"
+          >
+            <p className="flex-1 leading-snug">{toast.message}</p>
+            <button
+              type="button"
+              onClick={() => setToasts((current) => current.filter((item) => item.key !== toast.key))}
+              className="mt-0.5 rounded-full border border-transparent p-1 text-xs text-slate-200 transition hover:border-slate-200/60 hover:bg-slate-900/50 hover:text-white"
+              aria-label="Dismiss notification"
+            >
+              ×
+            </button>
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/ui/toast.ts
+++ b/src/ui/toast.ts
@@ -1,0 +1,28 @@
+const shownKeys = new Set<string>();
+
+export type ToastOptions = {
+  type?: 'info' | 'warning' | 'error';
+  timeoutMs?: number;
+};
+
+export function toastOnce(key: string, message: string, options: ToastOptions = {}) {
+  if (shownKeys.has(key)) return;
+  shownKeys.add(key);
+  window.dispatchEvent(
+    new CustomEvent('app:toast', {
+      detail: {
+        key,
+        message,
+        ...options,
+      },
+    })
+  );
+}
+
+export function resetToastKey(key: string) {
+  shownKeys.delete(key);
+}
+
+export function clearToastKeys() {
+  shownKeys.clear();
+}

--- a/src/utils/iss.ts
+++ b/src/utils/iss.ts
@@ -1,7 +1,5 @@
 import * as THREE from 'three';
 
-const ISS_TLE_URL = 'https://celestrak.org/NORAD/elements/gp.php?CATNR=25544&FORMAT=TLE';
-
 export const FALLBACK_TLE: TleSet = {
   line1: '1 25544U 98067A   24103.43211991  .00018476  00000+0  32968-3 0  9993',
   line2: '2 25544  51.6405  60.2146 0004116 162.5696 274.5025 15.50060690552077',
@@ -160,26 +158,6 @@ const eciToGeodetic = (positionEci: THREE.Vector3, gmst: number) => {
     latitude,
     altitude,
   };
-};
-
-export const fetchLatestTle = async (): Promise<TleSet> => {
-  const response = await fetch(ISS_TLE_URL, { cache: 'no-store' });
-  if (!response.ok) {
-    throw new Error(`Failed to fetch ISS TLE: ${response.status} ${response.statusText}`);
-  }
-  const text = await response.text();
-  const lines = text
-    .split('\n')
-    .map((line) => line.trim())
-    .filter((line) => line.length > 0);
-  const [line1 = '', line2 = ''] = lines.slice(-2);
-  if (!line1 || !line2) {
-    throw new Error('Unable to retrieve ISS TLE');
-  }
-  if (!line1.startsWith('1 ') || !line2.startsWith('2 ')) {
-    throw new Error('Received malformed ISS TLE');
-  }
-  return { line1, line2 };
 };
 
 export const getIssPositionAt = (satrec: SimpleSatRec, timestamp: number): IssGeodeticPosition | null => {


### PR DESCRIPTION
## Summary
- add a reusable toast host and helper that only surfaces each fallback notification once
- introduce an orbitService with cached TLE storage, exponential retries, and a status API/broadcasts
- update the explorer UI to consume the status, surface a stale-data banner, and rely on cached TLEs during outages

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e14dd7093c8331bdc7b891582d5c7d