### PR TITLE
Refactor education page with interactive lesson modals

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,9 @@
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-router-dom": "^6.22.3",
-    "three": "^0.160.0"
+    "three": "^0.160.0",
+    "@react-three/fiber": "^8.15.16",
+    "framer-motion": "^11.0.3"
   },
   "devDependencies": {
     "@vitejs/plugin-react": "^4.2.1",

--- a/src/components/education/LessonVisual.tsx
+++ b/src/components/education/LessonVisual.tsx
@@ -1,0 +1,269 @@
+import { Suspense, useMemo } from 'react';
+import { Canvas, useFrame } from '@react-three/fiber';
+import type { Lesson } from '../../data/lessons';
+
+interface LessonVisualProps {
+  visual: Lesson['visual'];
+}
+
+const RotatingSphere = ({ color = '#38bdf8', emissive = '#0ea5e9' }: { color?: string; emissive?: string }) => {
+  useFrame((state) => {
+    const t = state.clock.getElapsedTime();
+    state.camera.position.x = Math.sin(t / 3) * 0.6;
+    state.camera.position.z = 2.5;
+    state.camera.lookAt(0, 0, 0);
+  });
+
+  return (
+    <mesh castShadow receiveShadow>
+      <sphereGeometry args={[1, 32, 32]} />
+      <meshStandardMaterial color={color} emissive={emissive} emissiveIntensity={0.3} metalness={0.1} roughness={0.5} />
+    </mesh>
+  );
+};
+
+const OrbitRing = () => (
+  <mesh rotation={[Math.PI / 2, 0, 0]}>
+    <ringGeometry args={[1.4, 1.45, 64]} />
+    <meshBasicMaterial color="#bae6fd" transparent opacity={0.4} />
+  </mesh>
+);
+
+const Satellite = () => {
+  useFrame((state, delta) => {
+    const mesh = state.scene.getObjectByName('satellite');
+    if (!mesh) {
+      return;
+    }
+    mesh.rotation.z += delta * 1.5;
+    mesh.position.x = Math.cos(state.clock.elapsedTime) * 1.4;
+    mesh.position.y = Math.sin(state.clock.elapsedTime) * 0.8;
+  });
+
+  return (
+    <mesh name="satellite">
+      <boxGeometry args={[0.25, 0.25, 0.5]} />
+      <meshStandardMaterial color="#facc15" emissive="#f59e0b" emissiveIntensity={0.6} />
+      <mesh position={[0, 0.3, 0]}>
+        <boxGeometry args={[0.02, 0.6, 0.4]} />
+        <meshStandardMaterial color="#e2e8f0" emissive="#f8fafc" emissiveIntensity={0.3} />
+      </mesh>
+    </mesh>
+  );
+};
+
+const DayNightTerminator = () => (
+  <mesh rotation={[0, Math.PI / 6, Math.PI / 9]}>
+    <sphereGeometry args={[1.02, 32, 32]} />
+    <meshStandardMaterial color="#020617" transparent opacity={0.6} />
+  </mesh>
+);
+
+const AuroraRibbon = () => {
+  useFrame((state) => {
+    const mesh = state.scene.getObjectByName('aurora');
+    if (!mesh) {
+      return;
+    }
+    mesh.position.y = Math.sin(state.clock.elapsedTime * 1.5) * 0.2;
+  });
+
+  return (
+    <mesh name="aurora" rotation={[Math.PI / 2, 0, 0]}>
+      <ringGeometry args={[0.9, 1.5, 64, 1, 0, Math.PI / 1.2]} />
+      <meshStandardMaterial color="#86efac" emissive="#22c55e" emissiveIntensity={0.5} transparent opacity={0.5} />
+    </mesh>
+  );
+};
+
+const CommunicationBeams = () => (
+  <group>
+    {[0, 1, 2].map((index) => (
+      <mesh key={index} rotation={[Math.PI / 2, 0, (Math.PI / 3) * index]} position={[0, 0, -0.2]}>
+        <cylinderGeometry args={[0.02, 0.06, 2, 12]} />
+        <meshStandardMaterial color="#38bdf8" emissive="#0ea5e9" emissiveIntensity={0.4} transparent opacity={0.6} />
+      </mesh>
+    ))}
+  </group>
+);
+
+const DockingArms = () => (
+  <group>
+    {[0, 1, 2].map((index) => (
+      <mesh key={index} rotation={[0, (Math.PI * 2 * index) / 3, 0]} position={[0, 0, 0]}>
+        <boxGeometry args={[1.8, 0.08, 0.08]} />
+        <meshStandardMaterial color="#cbd5f5" emissive="#818cf8" emissiveIntensity={0.3} />
+      </mesh>
+    ))}
+    <mesh>
+      <cylinderGeometry args={[0.4, 0.4, 0.2, 32]} />
+      <meshStandardMaterial color="#e2e8f0" roughness={0.4} metalness={0.2} />
+    </mesh>
+  </group>
+);
+
+const FutureHabitat = () => (
+  <group>
+    <mesh position={[0, 0.4, 0]}>
+      <boxGeometry args={[1.4, 0.4, 1.4]} />
+      <meshStandardMaterial color="#38bdf8" emissive="#22d3ee" emissiveIntensity={0.3} />
+    </mesh>
+    <mesh position={[0, -0.4, 0]}>
+      <boxGeometry args={[1.2, 0.4, 1.2]} />
+      <meshStandardMaterial color="#818cf8" emissive="#6366f1" emissiveIntensity={0.25} />
+    </mesh>
+    <mesh>
+      <cylinderGeometry args={[0.3, 0.3, 1.2, 32]} />
+      <meshStandardMaterial color="#c4b5fd" emissive="#a855f7" emissiveIntensity={0.2} />
+    </mesh>
+  </group>
+);
+
+const FloatingCrystals = () => {
+  useFrame((state) => {
+    state.scene.children
+      .filter((child) => child.name?.startsWith('crystal'))
+      .forEach((child, index) => {
+        child.rotation.x += 0.01 + index * 0.003;
+        child.rotation.y += 0.015 + index * 0.002;
+        child.position.y = Math.sin(state.clock.elapsedTime + index) * 0.4;
+      });
+  });
+
+  return (
+    <group>
+      {[0, 1, 2].map((index) => (
+        <mesh key={index} name={`crystal-${index}`} position={[index - 1, 0, 0]}>
+          <octahedronGeometry args={[0.35, 0]} />
+          <meshStandardMaterial color="#f472b6" emissive="#ec4899" emissiveIntensity={0.4} />
+        </mesh>
+      ))}
+    </group>
+  );
+};
+
+const InternationalOrbital = () => (
+  <group>
+    {[0, 1, 2, 3, 4].map((index) => (
+      <mesh key={index} position={[Math.cos((index / 5) * Math.PI * 2) * 1.2, Math.sin((index / 5) * Math.PI * 2) * 1.2, 0]}>
+        <sphereGeometry args={[0.2, 16, 16]} />
+        <meshStandardMaterial color="#facc15" emissive="#fde047" emissiveIntensity={0.4} />
+      </mesh>
+    ))}
+    <RotatingSphere color="#60a5fa" emissive="#3b82f6" />
+  </group>
+);
+
+const visualContentMap: Record<Lesson['visual'], JSX.Element> = {
+  orbit: (
+    <group>
+      <RotatingSphere />
+      <OrbitRing />
+      <Satellite />
+    </group>
+  ),
+  dayNight: (
+    <group>
+      <RotatingSphere color="#0ea5e9" emissive="#0284c7" />
+      <DayNightTerminator />
+    </group>
+  ),
+  cupola: (
+    <group>
+      <mesh>
+        <sphereGeometry args={[1, 6, 12]} />
+        <meshStandardMaterial color="#1e293b" wireframe opacity={0.8} />
+      </mesh>
+      <mesh>
+        <icosahedronGeometry args={[0.6, 1]} />
+        <meshStandardMaterial color="#38bdf8" emissive="#0ea5e9" emissiveIntensity={0.4} wireframe />
+      </mesh>
+    </group>
+  ),
+  aurora: (
+    <group>
+      <RotatingSphere color="#1e293b" emissive="#0f172a" />
+      <AuroraRibbon />
+    </group>
+  ),
+  life: (
+    <group>
+      <RotatingSphere color="#a855f7" emissive="#c026d3" />
+      <mesh position={[0, -1.3, 0]}>
+        <torusGeometry args={[1.4, 0.05, 16, 64]} />
+        <meshStandardMaterial color="#f472b6" emissive="#ec4899" emissiveIntensity={0.5} />
+      </mesh>
+    </group>
+  ),
+  orbitPhysics: (
+    <group>
+      <RotatingSphere color="#22d3ee" emissive="#06b6d4" />
+      <OrbitRing />
+    </group>
+  ),
+  international: <InternationalOrbital />,
+  microgravity: (
+    <group>
+      <FloatingCrystals />
+      <RotatingSphere color="#0ea5e9" emissive="#06b6d4" />
+    </group>
+  ),
+  earthObservation: (
+    <group>
+      <RotatingSphere color="#38bdf8" emissive="#22d3ee" />
+      <mesh rotation={[Math.PI / 2, 0, 0]}>
+        <ringGeometry args={[1.2, 1.25, 64]} />
+        <meshStandardMaterial color="#fbbf24" emissive="#f59e0b" emissiveIntensity={0.5} transparent opacity={0.5} />
+      </mesh>
+    </group>
+  ),
+  communications: (
+    <group>
+      <RotatingSphere color="#6366f1" emissive="#4338ca" />
+      <CommunicationBeams />
+    </group>
+  ),
+  docking: (
+    <group>
+      <RotatingSphere color="#38bdf8" emissive="#0ea5e9" />
+      <DockingArms />
+    </group>
+  ),
+  future: (
+    <group>
+      <RotatingSphere color="#a855f7" emissive="#7c3aed" />
+      <FutureHabitat />
+    </group>
+  ),
+};
+
+const Placeholder = () => (
+  <div className="flex h-full w-full items-center justify-center rounded-3xl bg-gradient-to-br from-slate-900 via-slate-950 to-slate-900 text-xs uppercase tracking-[0.35em] text-slate-400">
+    Visual loading
+  </div>
+);
+
+const LessonVisual = ({ visual }: LessonVisualProps) => {
+  const canvas = useMemo(
+    () => (
+      <Canvas camera={{ position: [0, 0, 2.5], fov: 45 }} className="h-full w-full">
+        <color attach="background" args={["#020617"]} />
+        <ambientLight intensity={0.6} />
+        <directionalLight position={[3, 3, 5]} intensity={1.2} />
+        <Suspense fallback={null}>{visualContentMap[visual]}</Suspense>
+      </Canvas>
+    ),
+    [visual],
+  );
+
+  return (
+    <div className="relative h-64 w-full overflow-hidden rounded-[1.75rem] border border-slate-800/60 bg-slate-950/80 shadow-[0_35px_120px_-60px_rgba(56,189,248,0.9)]">
+      <Suspense fallback={<Placeholder />}>{canvas}</Suspense>
+      <div className="pointer-events-none absolute inset-x-6 bottom-4 flex justify-end text-[10px] uppercase tracking-[0.45em] text-slate-400/70">
+        {visual.replace(/([A-Z])/g, ' $1')}
+      </div>
+    </div>
+  );
+};
+
+export default LessonVisual;

--- a/src/data/lessons.ts
+++ b/src/data/lessons.ts
@@ -4,6 +4,21 @@ export interface Lesson {
   description: string;
   details: string;
   explorerFeature: string;
+  facts: string[];
+  visual:
+    | 'orbit'
+    | 'dayNight'
+    | 'cupola'
+    | 'aurora'
+    | 'life'
+    | 'orbitPhysics'
+    | 'international'
+    | 'microgravity'
+    | 'earthObservation'
+    | 'communications'
+    | 'docking'
+    | 'future';
+  funFact: string;
 }
 
 export const lessonData: Lesson[] = [
@@ -15,6 +30,9 @@ export const lessonData: Lesson[] = [
     details:
       'The International Space Station hurtles around Earth at a remarkable 27,571 kilometers per hour (17,150 mph). That velocity is fast enough to cross the continental United States in about ten minutes, keeping the laboratory in constant free fall around the planet. Because astronauts live in a perpetual state of microgravity, the station’s speed is critical to maintaining its stable orbit.\n\nTraveling this quickly means the station completes an orbit roughly every 90 minutes. Astronauts aboard the ISS therefore transition from sunlight to darkness dozens of times per day, experiencing sunrise or sunset approximately every 45 minutes. Mission controllers must carefully plan activities to match this relentless rhythm.\n\nMaintaining the precise orbital speed also protects the station from atmospheric drag. Small engine burns are scheduled to counter the thin traces of Earth’s atmosphere that still brush the ISS at its altitude, ensuring it remains high enough to avoid re-entry.',
     explorerFeature: 'orbit-speed',
+    facts: ['Speed: 27,571 km/h', '90-minute orbits', '16 sunrises every day'],
+    visual: 'orbit',
+    funFact: 'In the time it takes you to watch a movie, the ISS has circled Earth nearly twice.',
   },
   {
     id: 2,
@@ -23,6 +41,9 @@ export const lessonData: Lesson[] = [
     details:
       'Because the ISS loops around Earth every 90 minutes, crew members witness daybreak and nightfall many times during a single shift. Each orbit carries the station through alternating arcs of daylight and darkness, resulting in about 16 sunrises and 16 sunsets every 24 hours. The spectacle paints the horizon with vivid colors that race across the windows in mere moments.\n\nThis rapid light cycle can challenge human circadian rhythms. Astronauts rely on carefully programmed lighting inside the station, along with strict sleep schedules, to signal to their bodies when it is time to rest. Mission planners also choreograph activities to minimize fatigue, particularly during spacewalk preparations when alertness is vital.\n\nStudying how the body adapts to these rapid transitions helps scientists design lighting systems and routines for future deep-space missions. Lessons learned from the ISS inform how crews might live on voyages to the Moon, Mars, and beyond.',
     explorerFeature: 'day-night-cycle',
+    facts: ['1 orbit = 90 minutes', 'Day/night changes every 45 minutes', 'Lighting helps regulate sleep'],
+    visual: 'dayNight',
+    funFact: 'Astronauts sometimes wear light-blocking visors at “night” so their brains know it is time to sleep.',
   },
   {
     id: 3,
@@ -31,6 +52,9 @@ export const lessonData: Lesson[] = [
     details:
       'The Cupola module is a seven-window observatory perched on the ISS that provides astronauts with a sweeping panorama of Earth and space. Its central round window is the largest ever flown on a spacecraft, allowing crew members to admire swirling weather systems, glowing city lights, and the thin blue line of Earth’s atmosphere.\n\nBeyond its unmatched view, the Cupola is a functional workstation. Astronauts use it to operate the Canadarm2 robotic arm, monitor visiting spacecraft, and oversee spacewalks. The surrounding equipment consoles glow with instrument readouts, framing Earth’s beauty with the practical tools of orbital operations.\n\nThe Cupola has also become an iconic venue for photography. Images captured here help scientists track natural events like hurricanes, volcanic eruptions, and glacial changes, while inspiring people on Earth with the fragility and wonder of our planet.',
     explorerFeature: 'cupola-view',
+    facts: ['Seven-window observation dome', 'Built by the European Space Agency', 'Hosts the Canadarm2 controls'],
+    visual: 'cupola',
+    funFact: 'Astronaut Tracy Caldwell Dyson once spent her off-duty time recording poetry readings from the Cupola.',
   },
   {
     id: 4,
@@ -39,69 +63,96 @@ export const lessonData: Lesson[] = [
     details:
       'Auroras ignite when charged particles from the Sun stream along Earth’s magnetic field and collide with atoms in the upper atmosphere. From the ISS, astronauts often watch these storms of light ripple beneath them like neon curtains draped over the poles. Greens, purples, and reds shimmer along the horizon, sometimes stretching thousands of kilometers across.\n\nScientists study auroras from orbit to understand how solar activity influences our planet. Observations from the station complement measurements from satellites and ground-based telescopes, offering unique vantage points on the shape and movement of these glowing ribbons.\n\nFor the crew, aurora sightings are a cherished perk of orbital life. Many describe the experience as a reminder of Earth’s delicate shield against the harsh environment of space, reinforcing the importance of monitoring our planet’s magnetic and atmospheric health.',
     explorerFeature: 'aurora',
+    facts: ['Caused by solar wind particles', 'Best seen near the poles', 'Colors depend on atmospheric gases'],
+    visual: 'aurora',
+    funFact: 'Some auroras are so bright that astronauts can read checklists by their glow.',
   },
   {
     id: 5,
     title: 'Life on the ISS',
     description: 'Discover how astronauts eat, sleep, and live in microgravity.',
     details:
-      'Astronauts aboard the ISS live in microgravity, where every daily task becomes a challenge. Sleeping requires sleeping bags strapped to walls, food must be eaten from sealed pouches, and exercise is critical to avoid muscle loss. This lesson explores daily life in orbit.',
+      'Astronauts aboard the ISS live in microgravity, where every daily task becomes a challenge. Sleeping requires strapping themselves into sleeping bags so they do not drift around. Meals arrive dehydrated or thermostabilized, and each pouch must be carefully managed so crumbs and droplets do not float away.\n\nTo stay healthy, crew members exercise around two hours each day using treadmills, stationary bikes, and resistive machines. Without this routine, muscles and bones weaken quickly. Astronauts also schedule regular medical checks, coordinate video calls with family, and carve out time for science experiments and maintenance tasks.',
     explorerFeature: 'life-on-iss',
+    facts: ['Two hours of exercise daily', 'Sleeping bags attach to walls', 'Food is carefully packaged'],
+    visual: 'life',
+    funFact: 'Velcro is everywhere aboard the ISS—it keeps pens, utensils, and experiments from floating away.',
   },
   {
     id: 6,
     title: 'Why the ISS Doesn’t Fall',
     description: 'Understand the physics behind the ISS staying in orbit.',
     details:
-      'The ISS is constantly falling toward Earth, but because it moves forward so fast, it keeps missing the planet. This is called free fall or orbit. Gravity and velocity balance each other, keeping the ISS in stable orbit.',
+      'The ISS is constantly falling toward Earth, but its tremendous forward speed means it keeps missing the planet. This balance between gravity’s pull and orbital velocity creates continuous free fall, known as orbit. Astronauts feel weightless because they fall at the same rate as their spacecraft.\n\nControllers perform periodic reboost maneuvers to counter atmospheric drag. These small engine burns nudge the station to higher altitudes, keeping the balance between gravity and speed intact and ensuring the laboratory remains aloft.',
     explorerFeature: 'why-iss-doesnt-fall',
+    facts: ['Orbit is continuous free fall', 'Reboost burns fight drag', 'Velocity balances gravity'],
+    visual: 'orbitPhysics',
+    funFact: 'Even at 400 km up, traces of atmosphere still tug on the ISS and gradually slow it down.',
   },
   {
     id: 7,
     title: 'International Crew',
     description: 'Learn about the astronauts and nations that work together on the ISS.',
     details:
-      'The ISS is a symbol of global cooperation, with contributions from NASA (USA), Roscosmos (Russia), ESA (Europe), JAXA (Japan), and CSA (Canada). Astronauts from many nations rotate aboard, working together in science, engineering, and exploration.',
+      'The ISS is a symbol of global cooperation. NASA, Roscosmos, ESA, JAXA, and CSA built and operate the outpost together, coordinating everything from launch schedules to science programs. Crew members often speak multiple languages to collaborate seamlessly during spacewalks and experiments.\n\nInternational partners share responsibilities for resupply missions, power systems, and research priorities. This teamwork showcases how nations can pool resources to tackle complex challenges in space.',
     explorerFeature: 'international-crew',
+    facts: ['15 nations have flown crew', 'Mission control spans continents', 'Shared science goals unite partners'],
+    visual: 'international',
+    funFact: 'The ISS’s official languages are English and Russian, and every astronaut learns key phrases in both.',
   },
   {
     id: 8,
     title: 'Experiments in Microgravity',
     description: 'See why the ISS is the world’s most unique science lab.',
     details:
-      'The ISS is used to study how microgravity affects biology, physics, medicine, and materials. Experiments range from protein crystallization to fluid dynamics, offering insights impossible to achieve on Earth.',
+      'The ISS enables experiments impossible on Earth. In microgravity, flames form spheres, fluids behave strangely, and biological systems reveal how gravity shapes life. Scientists study everything from crystal growth to human immune responses using the station’s specialized facilities.\n\nResults feed into medicine, materials science, and future exploration. Insights gained in orbit help design lighter alloys, more effective drugs, and life-support systems for deep-space missions.',
     explorerFeature: 'microgravity-experiments',
+    facts: ['Microgravity changes fluid behavior', 'Over 3,000 experiments so far', 'Findings improve life on Earth'],
+    visual: 'microgravity',
+    funFact: 'Protein crystals grown on the ISS can be up to 10 times larger than those made on Earth.',
   },
   {
     id: 9,
     title: 'Earth Observation',
     description: 'Explore how astronauts and instruments monitor Earth from space.',
     details:
-      'From its vantage point, the ISS provides an unparalleled view of Earth. Astronauts capture breathtaking images, while instruments track storms, wildfires, deforestation, and climate change.',
+      'From its vantage point, the ISS offers sweeping views of our planet. Astronauts use handheld cameras to capture storms, wildfires, and coastlines in stunning detail. These images support disaster response teams, environmental researchers, and educators around the world.\n\nMounted instruments gather data on atmospheric chemistry, ocean color, and changes in vegetation. Combining human observations with sensor readings provides a richer understanding of Earth’s dynamic systems.',
     explorerFeature: 'earth-observation',
+    facts: ['Crew take thousands of photos yearly', 'Instruments monitor climate trends', 'Data assists disaster response'],
+    visual: 'earthObservation',
+    funFact: 'Some of the most detailed lightning studies come from cameras pointed out of the ISS windows.',
   },
   {
     id: 10,
     title: 'Communications with Earth',
     description: 'How the ISS stays connected with mission control and families.',
     details:
-      'The ISS relies on satellites like NASA’s Tracking and Data Relay Satellites (TDRS) to stay in constant contact with Earth. Data, voice, and video are transmitted to mission control, while astronauts also have access to email and video calls with families.',
+      'The ISS relies on a network of Tracking and Data Relay Satellites (TDRS) to transmit voice, video, and science data. These satellites route signals between the station and ground antennas, ensuring controllers can monitor systems in real time.\n\nAstronauts also benefit from internet-linked services for email, video calls, and live broadcasts. Delays are minimal thanks to the satellite network, keeping the crew connected to loved ones and classrooms.',
     explorerFeature: 'communications',
+    facts: ['TDRS network keeps contact continuous', 'Voice, video, and telemetry stream constantly', 'Crew can video chat with family'],
+    visual: 'communications',
+    funFact: 'Astronauts occasionally join live TV interviews from orbit using the same communications network.',
   },
   {
     id: 11,
     title: 'Docking and Visiting Vehicles',
     description: 'Learn how spacecraft like Dragon and Soyuz dock with the ISS.',
     details:
-      'The ISS receives cargo and crew from visiting spacecraft such as SpaceX Dragon, Northrop Grumman Cygnus, and Soyuz. Docking can be automatic or manually controlled, requiring extreme precision as spacecraft travel thousands of km/h.',
+      'The ISS receives cargo and crew from visiting spacecraft such as SpaceX Dragon, Boeing Starliner, Northrop Grumman Cygnus, and Soyuz. Approaching vehicles follow precise trajectories, guided by GPS, lasers, and crew monitoring from inside the station.\n\nSome spacecraft dock autonomously, while others require manual control using joysticks and cameras. Every arrival brings fresh supplies, experiments, and sometimes new modules.',
     explorerFeature: 'docking',
+    facts: ['Multiple spacecraft visit yearly', 'Autonomous and manual dockings occur', 'Cargo delivers experiments and fuel'],
+    visual: 'docking',
+    funFact: 'The Canadarm2 robotic arm can capture spacecraft that do not dock on their own, like Northrop Grumman’s Cygnus.',
   },
   {
     id: 12,
     title: 'Future of the ISS',
     description: 'Discover what’s next for the station and space habitats.',
     details:
-      'The ISS has been in operation since 1998, but its mission will eventually transition to commercial space stations and deep space exploration. New concepts include private modules, lunar Gateway, and Mars preparation.',
+      'The ISS has been in operation since 1998, but its mission is evolving. NASA and its partners plan to transition research to commercial space stations later in the decade, freeing resources for deep-space exploration. Companies are already designing free-flying laboratories and commercial modules.\n\nLessons from the ISS inform the Lunar Gateway, a planned outpost around the Moon that will support Artemis missions. The experience gained in long-duration spaceflight will also prepare crews for eventual voyages to Mars.',
     explorerFeature: 'future-of-iss',
+    facts: ['Commercial stations are in development', 'Lunar Gateway builds on ISS lessons', 'ISS operations extend through 2030'],
+    visual: 'future',
+    funFact: 'Some ISS modules may be detached and reused as part of commercial stations after retirement.',
   },
 ];


### PR DESCRIPTION
## Summary
- add framer-motion and react-three-fiber dependencies for animation and interactive visuals
- expand lesson dataset with key facts, fun facts, and visual identifiers
- replace static lesson cards with animated modal experience that includes navigation, progress, and rich visuals

## Testing
- npm install *(fails: 403 Forbidden from registry)*

------
https://chatgpt.com/codex/tasks/task_e_68e15af10de88331b988bc33bbcb5adf