### PR TITLE
feat: add cinematic lesson visuals

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,10 @@
     "react-router-dom": "^6.22.3",
     "three": "^0.160.0",
     "@react-three/fiber": "^8.15.16",
-    "framer-motion": "^11.0.3"
+    "@react-three/drei": "^9.109.0",
+    "@react-three/postprocessing": "^2.16.0",
+    "framer-motion": "^11.0.3",
+    "react-spring": "^9.7.3"
   },
   "devDependencies": {
     "@vitejs/plugin-react": "^4.2.1",

--- a/src/components/education/LessonModel.tsx
+++ b/src/components/education/LessonModel.tsx
@@ -1,0 +1,113 @@
+import { useEffect, useMemo, useRef, useState } from 'react';
+import { useFrame } from '@react-three/fiber';
+import { useAnimations, useGLTF } from '@react-three/drei';
+import { a, useSpring } from '@react-spring/three';
+import type { Group, Mesh } from 'three';
+
+interface LessonModelProps {
+  modelPath: string;
+  baseScale?: number;
+  position?: [number, number, number];
+  rotation?: [number, number, number];
+  rotationSpeed?: number;
+}
+
+const LessonModel = ({
+  modelPath,
+  baseScale = 1,
+  position = [0, 0, 0],
+  rotation = [0, 0, 0],
+  rotationSpeed = 0.002,
+}: LessonModelProps) => {
+  const groupRef = useRef<Group>(null);
+  const [hovered, setHovered] = useState(false);
+  const gltf = useGLTF(modelPath);
+  const { actions, names } = useAnimations(gltf.animations, groupRef);
+
+  useEffect(() => {
+    setHovered(false);
+  }, [modelPath]);
+
+  useEffect(() => {
+    if (!groupRef.current) {
+      return;
+    }
+    groupRef.current.rotation.set(rotation[0], rotation[1], rotation[2]);
+  }, [rotation]);
+
+  useEffect(() => {
+    names.forEach((name) => {
+      const action = actions[name];
+      action?.reset().fadeIn(0.6).play();
+    });
+
+    return () => {
+      names.forEach((name) => {
+        const action = actions[name];
+        if (!action) {
+          return;
+        }
+        action.fadeOut(0.3);
+        action.stop();
+      });
+    };
+  }, [actions, names]);
+
+  useFrame(() => {
+    if (!groupRef.current) {
+      return;
+    }
+    groupRef.current.rotation.y += rotationSpeed;
+  });
+
+  const [spring, api] = useSpring(() => ({
+    scale: baseScale * 0.7,
+    config: { tension: 120, friction: 18, mass: 1.1 },
+  }));
+
+  useEffect(() => {
+    api.start({ scale: baseScale });
+  }, [api, baseScale, modelPath]);
+
+  useEffect(() => {
+    api.start({ scale: hovered ? baseScale * 1.06 : baseScale });
+  }, [api, baseScale, hovered]);
+
+  const scene = useMemo(() => gltf.scene.clone(true), [gltf.scene]);
+
+  useEffect(() => {
+    scene.traverse((child) => {
+      const mesh = child as Mesh;
+      if (typeof mesh.castShadow === 'boolean') {
+        mesh.castShadow = true;
+      }
+      if (typeof mesh.receiveShadow === 'boolean') {
+        mesh.receiveShadow = true;
+      }
+    });
+  }, [scene]);
+
+  return (
+    <a.group
+      ref={groupRef}
+      position={position}
+      scale={spring.scale}
+      onPointerOver={(event) => {
+        event.stopPropagation();
+        setHovered(true);
+      }}
+      onPointerOut={(event) => {
+        event.stopPropagation();
+        setHovered(false);
+      }}
+    >
+      <primitive object={scene} dispose={null} />
+    </a.group>
+  );
+};
+
+export const preloadLessonModel = (path: string) => {
+  useGLTF.preload(path);
+};
+
+export default LessonModel;

--- a/src/components/education/LessonVisual.tsx
+++ b/src/components/education/LessonVisual.tsx
@@ -1,266 +1,415 @@
-import { Suspense, useMemo } from 'react';
-import { Canvas, useFrame } from '@react-three/fiber';
+import { Suspense, useEffect, useMemo } from 'react';
+import { Canvas, useFrame, useThree } from '@react-three/fiber';
+import { ContactShadows, Environment, OrbitControls } from '@react-three/drei';
+import { EffectComposer, Bloom } from '@react-three/postprocessing';
+import * as THREE from 'three';
 import type { Lesson } from '../../data/lessons';
+import LessonModel from './LessonModel';
 
 interface LessonVisualProps {
-  visual: Lesson['visual'];
+  lesson: Lesson;
 }
 
-const RotatingSphere = ({ color = '#38bdf8', emissive = '#0ea5e9' }: { color?: string; emissive?: string }) => {
-  useFrame((state) => {
-    const t = state.clock.getElapsedTime();
-    state.camera.position.x = Math.sin(t / 3) * 0.6;
-    state.camera.position.z = 2.5;
-    state.camera.lookAt(0, 0, 0);
-  });
+type Vector3Tuple = [number, number, number];
 
-  return (
-    <mesh castShadow receiveShadow>
-      <sphereGeometry args={[1, 32, 32]} />
-      <meshStandardMaterial color={color} emissive={emissive} emissiveIntensity={0.3} metalness={0.1} roughness={0.5} />
-    </mesh>
-  );
+interface CameraConfig {
+  position: Vector3Tuple;
+  target: Vector3Tuple;
+  parallax: { x: number; y: number };
+}
+
+interface ModelConfig {
+  scale: number;
+  position: Vector3Tuple;
+  rotation: Vector3Tuple;
+  rotationSpeed: number;
+}
+
+interface BloomConfig {
+  intensity: number;
+  threshold: number;
+  smoothing: number;
+}
+
+interface ContactShadowConfig {
+  scale: number;
+  blur: number;
+  opacity: number;
+  far: number;
+  position: Vector3Tuple;
+}
+
+interface DirectionalLightConfig {
+  position: Vector3Tuple;
+  intensity: number;
+  color?: string;
+}
+
+interface LightConfig {
+  ambient: number;
+  directional: DirectionalLightConfig[];
+}
+
+interface SceneConfig {
+  camera: CameraConfig;
+  model: ModelConfig;
+  bloom: BloomConfig;
+  lights: LightConfig;
+  contactShadow: ContactShadowConfig;
+  environment: 'apartment' | 'city' | 'dawn' | 'forest' | 'lobby' | 'night' | 'park' | 'studio' | 'sunset' | 'warehouse';
+}
+
+interface PartialSceneConfig {
+  camera?: Partial<CameraConfig>;
+  model?: Partial<ModelConfig>;
+  bloom?: Partial<BloomConfig>;
+  lights?: Partial<LightConfig>;
+  contactShadow?: Partial<ContactShadowConfig>;
+  environment?: SceneConfig['environment'];
+}
+
+const baseSceneConfig: SceneConfig = {
+  camera: {
+    position: [0.15, 0.3, 4.2],
+    target: [0, 0, 0],
+    parallax: { x: 0.32, y: 0.22 },
+  },
+  model: {
+    scale: 1,
+    position: [0, -0.3, 0],
+    rotation: [0, Math.PI / 6, 0],
+    rotationSpeed: 0.002,
+  },
+  bloom: {
+    intensity: 0.55,
+    threshold: 0.22,
+    smoothing: 0.75,
+  },
+  lights: {
+    ambient: 0.65,
+    directional: [
+      { position: [4, 6, 8], intensity: 1.6, color: '#9ec5ff' },
+      { position: [-5, -2, -4], intensity: 0.8, color: '#1e2a4a' },
+    ],
+  },
+  contactShadow: {
+    scale: 6,
+    blur: 2.5,
+    opacity: 0.45,
+    far: 6,
+    position: [0, -1.2, 0],
+  },
+  environment: 'city',
 };
 
-const OrbitRing = () => (
-  <mesh rotation={[Math.PI / 2, 0, 0]}>
-    <ringGeometry args={[1.4, 1.45, 64]} />
-    <meshBasicMaterial color="#bae6fd" transparent opacity={0.4} />
-  </mesh>
-);
-
-const Satellite = () => {
-  useFrame((state, delta) => {
-    const mesh = state.scene.getObjectByName('satellite');
-    if (!mesh) {
-      return;
-    }
-    mesh.rotation.z += delta * 1.5;
-    mesh.position.x = Math.cos(state.clock.elapsedTime) * 1.4;
-    mesh.position.y = Math.sin(state.clock.elapsedTime) * 0.8;
-  });
-
-  return (
-    <mesh name="satellite">
-      <boxGeometry args={[0.25, 0.25, 0.5]} />
-      <meshStandardMaterial color="#facc15" emissive="#f59e0b" emissiveIntensity={0.6} />
-      <mesh position={[0, 0.3, 0]}>
-        <boxGeometry args={[0.02, 0.6, 0.4]} />
-        <meshStandardMaterial color="#e2e8f0" emissive="#f8fafc" emissiveIntensity={0.3} />
-      </mesh>
-    </mesh>
-  );
+const sceneOverrides: Record<Lesson['visual'], PartialSceneConfig> = {
+  orbit: {
+    camera: {
+      position: [0.25, 0.4, 4.6],
+      parallax: { x: 0.34, y: 0.24 },
+    },
+    model: {
+      scale: 1.1,
+      rotationSpeed: 0.0024,
+    },
+    bloom: {
+      intensity: 0.62,
+      threshold: 0.2,
+    },
+  },
+  dayNight: {
+    environment: 'sunset',
+    lights: {
+      ambient: 0.55,
+      directional: [
+        { position: [5, 4, 6], intensity: 1.4, color: '#ffd29d' },
+        { position: [-4, -3, -4], intensity: 0.7, color: '#18314f' },
+      ],
+    },
+    model: {
+      scale: 1.05,
+      rotation: [0.1, Math.PI / 4, 0],
+    },
+    bloom: {
+      intensity: 0.48,
+      threshold: 0.26,
+    },
+  },
+  cupola: {
+    environment: 'night',
+    camera: {
+      position: [-0.2, 0.25, 4],
+      parallax: { x: 0.28, y: 0.2 },
+    },
+    lights: {
+      ambient: 0.5,
+      directional: [
+        { position: [3, 5, 6], intensity: 1.3, color: '#6ca8ff' },
+        { position: [-3, -3, -4], intensity: 0.65, color: '#1f2937' },
+      ],
+    },
+    model: {
+      scale: 1.15,
+      position: [0, -0.4, 0],
+      rotationSpeed: 0.0021,
+    },
+  },
+  aurora: {
+    environment: 'night',
+    lights: {
+      ambient: 0.45,
+      directional: [
+        { position: [3, 5, 5], intensity: 1.5, color: '#8ff0c0' },
+        { position: [-4, -2, -4], intensity: 0.75, color: '#14203b' },
+      ],
+    },
+    bloom: {
+      intensity: 0.78,
+      threshold: 0.18,
+    },
+    model: {
+      scale: 1.22,
+      rotationSpeed: 0.0018,
+    },
+  },
+  life: {
+    environment: 'studio',
+    lights: {
+      ambient: 0.7,
+      directional: [
+        { position: [5, 4, 6], intensity: 1.4, color: '#f9d6ff' },
+        { position: [-4, -3, -5], intensity: 0.85, color: '#1f2a44' },
+      ],
+    },
+    model: {
+      scale: 1.1,
+      position: [0, -0.2, 0],
+      rotation: [0, Math.PI / 8, 0],
+      rotationSpeed: 0.0025,
+    },
+  },
+  orbitPhysics: {
+    camera: {
+      position: [0.3, 0.35, 4.4],
+    },
+    model: {
+      scale: 1.12,
+      rotationSpeed: 0.0028,
+    },
+    lights: {
+      ambient: 0.6,
+      directional: [
+        { position: [4.5, 5, 7], intensity: 1.6, color: '#8bd0ff' },
+        { position: [-5, -3, -4.5], intensity: 0.9, color: '#162035' },
+      ],
+    },
+  },
+  international: {
+    environment: 'apartment',
+    lights: {
+      ambient: 0.75,
+      directional: [
+        { position: [4, 6, 8], intensity: 1.45, color: '#ffe58f' },
+        { position: [-6, -3, -4], intensity: 0.82, color: '#273149' },
+      ],
+    },
+    model: {
+      scale: 1.05,
+      rotationSpeed: 0.0022,
+    },
+  },
+  microgravity: {
+    environment: 'studio',
+    bloom: {
+      intensity: 0.68,
+      threshold: 0.2,
+    },
+    model: {
+      scale: 1.18,
+      rotation: [0.15, Math.PI / 3, 0.05],
+    },
+  },
+  earthObservation: {
+    environment: 'sunset',
+    lights: {
+      ambient: 0.6,
+      directional: [
+        { position: [5, 5, 7], intensity: 1.5, color: '#ffe1a8' },
+        { position: [-5, -2, -5], intensity: 0.8, color: '#1a2538' },
+      ],
+    },
+    model: {
+      scale: 1.16,
+      rotation: [0.05, Math.PI / 5, 0],
+      rotationSpeed: 0.0023,
+    },
+  },
+  communications: {
+    environment: 'studio',
+    lights: {
+      ambient: 0.65,
+      directional: [
+        { position: [4, 6, 7], intensity: 1.55, color: '#8bbcff' },
+        { position: [-4, -2, -4], intensity: 0.85, color: '#1a2a45' },
+      ],
+    },
+    bloom: {
+      intensity: 0.7,
+      threshold: 0.21,
+    },
+    model: {
+      scale: 1.08,
+      rotationSpeed: 0.0026,
+    },
+  },
+  docking: {
+    environment: 'warehouse',
+    lights: {
+      ambient: 0.6,
+      directional: [
+        { position: [6, 4, 7], intensity: 1.65, color: '#9ecaff' },
+        { position: [-4, -3, -4], intensity: 0.95, color: '#141d2e' },
+      ],
+    },
+    model: {
+      scale: 1.12,
+      rotation: [0.08, Math.PI / 3.2, 0],
+    },
+  },
+  future: {
+    environment: 'dawn',
+    lights: {
+      ambient: 0.7,
+      directional: [
+        { position: [5, 5, 6], intensity: 1.6, color: '#ffd1ff' },
+        { position: [-4, -3, -4], intensity: 0.9, color: '#18243a' },
+      ],
+    },
+    bloom: {
+      intensity: 0.75,
+      threshold: 0.19,
+    },
+    model: {
+      scale: 1.14,
+      rotationSpeed: 0.0021,
+    },
+  },
 };
 
-const DayNightTerminator = () => (
-  <mesh rotation={[0, Math.PI / 6, Math.PI / 9]}>
-    <sphereGeometry args={[1.02, 32, 32]} />
-    <meshStandardMaterial color="#020617" transparent opacity={0.6} />
-  </mesh>
-);
+const mergeSceneConfig = (override: PartialSceneConfig | undefined): SceneConfig => {
+  if (!override) {
+    return baseSceneConfig;
+  }
 
-const AuroraRibbon = () => {
-  useFrame((state) => {
-    const mesh = state.scene.getObjectByName('aurora');
-    if (!mesh) {
-      return;
-    }
-    mesh.position.y = Math.sin(state.clock.elapsedTime * 1.5) * 0.2;
-  });
-
-  return (
-    <mesh name="aurora" rotation={[Math.PI / 2, 0, 0]}>
-      <ringGeometry args={[0.9, 1.5, 64, 1, 0, Math.PI / 1.2]} />
-      <meshStandardMaterial color="#86efac" emissive="#22c55e" emissiveIntensity={0.5} transparent opacity={0.5} />
-    </mesh>
-  );
+  return {
+    camera: {
+      position: override.camera?.position ?? baseSceneConfig.camera.position,
+      target: override.camera?.target ?? baseSceneConfig.camera.target,
+      parallax: override.camera?.parallax ?? baseSceneConfig.camera.parallax,
+    },
+    model: {
+      scale: override.model?.scale ?? baseSceneConfig.model.scale,
+      position: override.model?.position ?? baseSceneConfig.model.position,
+      rotation: override.model?.rotation ?? baseSceneConfig.model.rotation,
+      rotationSpeed: override.model?.rotationSpeed ?? baseSceneConfig.model.rotationSpeed,
+    },
+    bloom: {
+      intensity: override.bloom?.intensity ?? baseSceneConfig.bloom.intensity,
+      threshold: override.bloom?.threshold ?? baseSceneConfig.bloom.threshold,
+      smoothing: override.bloom?.smoothing ?? baseSceneConfig.bloom.smoothing,
+    },
+    lights: {
+      ambient: override.lights?.ambient ?? baseSceneConfig.lights.ambient,
+      directional: override.lights?.directional ?? baseSceneConfig.lights.directional,
+    },
+    contactShadow: {
+      scale: override.contactShadow?.scale ?? baseSceneConfig.contactShadow.scale,
+      blur: override.contactShadow?.blur ?? baseSceneConfig.contactShadow.blur,
+      opacity: override.contactShadow?.opacity ?? baseSceneConfig.contactShadow.opacity,
+      far: override.contactShadow?.far ?? baseSceneConfig.contactShadow.far,
+      position: override.contactShadow?.position ?? baseSceneConfig.contactShadow.position,
+    },
+    environment: override.environment ?? baseSceneConfig.environment,
+  };
 };
 
-const CommunicationBeams = () => (
-  <group>
-    {[0, 1, 2].map((index) => (
-      <mesh key={index} rotation={[Math.PI / 2, 0, (Math.PI / 3) * index]} position={[0, 0, -0.2]}>
-        <cylinderGeometry args={[0.02, 0.06, 2, 12]} />
-        <meshStandardMaterial color="#38bdf8" emissive="#0ea5e9" emissiveIntensity={0.4} transparent opacity={0.6} />
-      </mesh>
+const ParallaxCameraRig = ({ config }: { config: SceneConfig['camera'] }) => {
+  const { camera } = useThree();
+  const target = useMemo(() => new THREE.Vector3(...config.target), [config.target]);
+  const basePosition = useMemo(() => new THREE.Vector3(...config.position), [config.position]);
+
+  useEffect(() => {
+    camera.position.set(basePosition.x, basePosition.y, basePosition.z);
+    camera.lookAt(target);
+  }, [basePosition, camera, target]);
+
+  useFrame(({ mouse }) => {
+    const nextX = basePosition.x + mouse.x * config.parallax.x;
+    const nextY = basePosition.y + mouse.y * config.parallax.y;
+    camera.position.x = THREE.MathUtils.lerp(camera.position.x, nextX, 0.06);
+    camera.position.y = THREE.MathUtils.lerp(camera.position.y, nextY, 0.06);
+    camera.position.z = THREE.MathUtils.lerp(camera.position.z, basePosition.z, 0.06);
+    camera.lookAt(target);
+  });
+
+  return null;
+};
+
+const CinematicLights = ({ lights }: { lights: LightConfig }) => (
+  <>
+    <ambientLight intensity={lights.ambient} />
+    {lights.directional.map((light, index) => (
+      <directionalLight key={`dir-${index}`} position={light.position} intensity={light.intensity} color={light.color} />
     ))}
-  </group>
+  </>
 );
 
-const DockingArms = () => (
-  <group>
-    {[0, 1, 2].map((index) => (
-      <mesh key={index} rotation={[0, (Math.PI * 2 * index) / 3, 0]} position={[0, 0, 0]}>
-        <boxGeometry args={[1.8, 0.08, 0.08]} />
-        <meshStandardMaterial color="#cbd5f5" emissive="#818cf8" emissiveIntensity={0.3} />
-      </mesh>
-    ))}
-    <mesh>
-      <cylinderGeometry args={[0.4, 0.4, 0.2, 32]} />
-      <meshStandardMaterial color="#e2e8f0" roughness={0.4} metalness={0.2} />
-    </mesh>
-  </group>
-);
-
-const FutureHabitat = () => (
-  <group>
-    <mesh position={[0, 0.4, 0]}>
-      <boxGeometry args={[1.4, 0.4, 1.4]} />
-      <meshStandardMaterial color="#38bdf8" emissive="#22d3ee" emissiveIntensity={0.3} />
-    </mesh>
-    <mesh position={[0, -0.4, 0]}>
-      <boxGeometry args={[1.2, 0.4, 1.2]} />
-      <meshStandardMaterial color="#818cf8" emissive="#6366f1" emissiveIntensity={0.25} />
-    </mesh>
-    <mesh>
-      <cylinderGeometry args={[0.3, 0.3, 1.2, 32]} />
-      <meshStandardMaterial color="#c4b5fd" emissive="#a855f7" emissiveIntensity={0.2} />
-    </mesh>
-  </group>
-);
-
-const FloatingCrystals = () => {
-  useFrame((state) => {
-    state.scene.children
-      .filter((child) => child.name?.startsWith('crystal'))
-      .forEach((child, index) => {
-        child.rotation.x += 0.01 + index * 0.003;
-        child.rotation.y += 0.015 + index * 0.002;
-        child.position.y = Math.sin(state.clock.elapsedTime + index) * 0.4;
-      });
-  });
-
-  return (
-    <group>
-      {[0, 1, 2].map((index) => (
-        <mesh key={index} name={`crystal-${index}`} position={[index - 1, 0, 0]}>
-          <octahedronGeometry args={[0.35, 0]} />
-          <meshStandardMaterial color="#f472b6" emissive="#ec4899" emissiveIntensity={0.4} />
-        </mesh>
-      ))}
-    </group>
-  );
-};
-
-const InternationalOrbital = () => (
-  <group>
-    {[0, 1, 2, 3, 4].map((index) => (
-      <mesh key={index} position={[Math.cos((index / 5) * Math.PI * 2) * 1.2, Math.sin((index / 5) * Math.PI * 2) * 1.2, 0]}>
-        <sphereGeometry args={[0.2, 16, 16]} />
-        <meshStandardMaterial color="#facc15" emissive="#fde047" emissiveIntensity={0.4} />
-      </mesh>
-    ))}
-    <RotatingSphere color="#60a5fa" emissive="#3b82f6" />
-  </group>
-);
-
-const visualContentMap: Record<Lesson['visual'], JSX.Element> = {
-  orbit: (
-    <group>
-      <RotatingSphere />
-      <OrbitRing />
-      <Satellite />
-    </group>
-  ),
-  dayNight: (
-    <group>
-      <RotatingSphere color="#0ea5e9" emissive="#0284c7" />
-      <DayNightTerminator />
-    </group>
-  ),
-  cupola: (
-    <group>
-      <mesh>
-        <sphereGeometry args={[1, 6, 12]} />
-        <meshStandardMaterial color="#1e293b" wireframe opacity={0.8} />
-      </mesh>
-      <mesh>
-        <icosahedronGeometry args={[0.6, 1]} />
-        <meshStandardMaterial color="#38bdf8" emissive="#0ea5e9" emissiveIntensity={0.4} wireframe />
-      </mesh>
-    </group>
-  ),
-  aurora: (
-    <group>
-      <RotatingSphere color="#1e293b" emissive="#0f172a" />
-      <AuroraRibbon />
-    </group>
-  ),
-  life: (
-    <group>
-      <RotatingSphere color="#a855f7" emissive="#c026d3" />
-      <mesh position={[0, -1.3, 0]}>
-        <torusGeometry args={[1.4, 0.05, 16, 64]} />
-        <meshStandardMaterial color="#f472b6" emissive="#ec4899" emissiveIntensity={0.5} />
-      </mesh>
-    </group>
-  ),
-  orbitPhysics: (
-    <group>
-      <RotatingSphere color="#22d3ee" emissive="#06b6d4" />
-      <OrbitRing />
-    </group>
-  ),
-  international: <InternationalOrbital />,
-  microgravity: (
-    <group>
-      <FloatingCrystals />
-      <RotatingSphere color="#0ea5e9" emissive="#06b6d4" />
-    </group>
-  ),
-  earthObservation: (
-    <group>
-      <RotatingSphere color="#38bdf8" emissive="#22d3ee" />
-      <mesh rotation={[Math.PI / 2, 0, 0]}>
-        <ringGeometry args={[1.2, 1.25, 64]} />
-        <meshStandardMaterial color="#fbbf24" emissive="#f59e0b" emissiveIntensity={0.5} transparent opacity={0.5} />
-      </mesh>
-    </group>
-  ),
-  communications: (
-    <group>
-      <RotatingSphere color="#6366f1" emissive="#4338ca" />
-      <CommunicationBeams />
-    </group>
-  ),
-  docking: (
-    <group>
-      <RotatingSphere color="#38bdf8" emissive="#0ea5e9" />
-      <DockingArms />
-    </group>
-  ),
-  future: (
-    <group>
-      <RotatingSphere color="#a855f7" emissive="#7c3aed" />
-      <FutureHabitat />
-    </group>
-  ),
-};
-
-const Placeholder = () => (
-  <div className="flex h-full w-full items-center justify-center rounded-3xl bg-gradient-to-br from-slate-900 via-slate-950 to-slate-900 text-xs uppercase tracking-[0.35em] text-slate-400">
-    Visual loading
+const CanvasFallback = () => (
+  <div className="flex h-full w-full items-center justify-center rounded-[1.75rem] bg-gradient-to-br from-slate-950 via-slate-900 to-slate-950 text-[10px] uppercase tracking-[0.4em] text-slate-500/70">
+    Loading scene…
   </div>
 );
 
-const LessonVisual = ({ visual }: LessonVisualProps) => {
-  const canvas = useMemo(
-    () => (
-      <Canvas camera={{ position: [0, 0, 2.5], fov: 45 }} className="h-full w-full">
-        <color attach="background" args={["#020617"]} />
-        <ambientLight intensity={0.6} />
-        <directionalLight position={[3, 3, 5]} intensity={1.2} />
-        <Suspense fallback={null}>{visualContentMap[visual]}</Suspense>
-      </Canvas>
-    ),
-    [visual],
-  );
+const LessonVisual = ({ lesson }: LessonVisualProps) => {
+  const config = useMemo(() => mergeSceneConfig(sceneOverrides[lesson.visual]), [lesson.visual]);
 
   return (
-    <div className="relative h-64 w-full overflow-hidden rounded-[1.75rem] border border-slate-800/60 bg-slate-950/80 shadow-[0_35px_120px_-60px_rgba(56,189,248,0.9)]">
-      <Suspense fallback={<Placeholder />}>{canvas}</Suspense>
+    <div className="relative h-[26rem] w-full overflow-hidden rounded-[1.75rem] border border-slate-800/60 bg-slate-950/80 shadow-[0_35px_120px_-60px_rgba(56,189,248,0.9)]">
+      <Suspense fallback={<CanvasFallback />}>
+        <Canvas
+          camera={{ position: config.camera.position, fov: 50 }}
+          dpr={[1, 1.8]}
+          gl={{ antialias: true, toneMapping: THREE.ACESFilmicToneMapping }}
+        >
+          <color attach="background" args={["#020617"]} />
+          <CinematicLights lights={config.lights} />
+          <Suspense fallback={null}>
+            <LessonModel
+              modelPath={lesson.model}
+              baseScale={config.model.scale}
+              position={config.model.position}
+              rotation={config.model.rotation}
+              rotationSpeed={config.model.rotationSpeed}
+            />
+            <Environment preset={config.environment} />
+          </Suspense>
+          <ContactShadows
+            opacity={config.contactShadow.opacity}
+            scale={config.contactShadow.scale}
+            blur={config.contactShadow.blur}
+            far={config.contactShadow.far}
+            position={config.contactShadow.position}
+          />
+          <EffectComposer disableNormalPass>
+            <Bloom intensity={config.bloom.intensity} luminanceThreshold={config.bloom.threshold} luminanceSmoothing={config.bloom.smoothing} />
+          </EffectComposer>
+          <OrbitControls enableZoom={false} enablePan={false} enableRotate={false} />
+          <ParallaxCameraRig config={config.camera} />
+        </Canvas>
+      </Suspense>
+      <div className="pointer-events-none absolute inset-0 bg-gradient-to-b from-transparent via-slate-950/10 to-slate-950/60" />
       <div className="pointer-events-none absolute inset-x-6 bottom-4 flex justify-end text-[10px] uppercase tracking-[0.45em] text-slate-400/70">
-        {visual.replace(/([A-Z])/g, ' $1')}
+        {lesson.title}
       </div>
     </div>
   );

--- a/src/data/lessons.ts
+++ b/src/data/lessons.ts
@@ -5,6 +5,7 @@ export interface Lesson {
   details: string;
   explorerFeature: string;
   facts: string[];
+  model: string;
   visual:
     | 'orbit'
     | 'dayNight'
@@ -31,6 +32,7 @@ export const lessonData: Lesson[] = [
       'The International Space Station hurtles around Earth at a remarkable 27,571 kilometers per hour (17,150 mph). That velocity is fast enough to cross the continental United States in about ten minutes, keeping the laboratory in constant free fall around the planet. Because astronauts live in a perpetual state of microgravity, the station’s speed is critical to maintaining its stable orbit.\n\nTraveling this quickly means the station completes an orbit roughly every 90 minutes. Astronauts aboard the ISS therefore transition from sunlight to darkness dozens of times per day, experiencing sunrise or sunset approximately every 45 minutes. Mission controllers must carefully plan activities to match this relentless rhythm.\n\nMaintaining the precise orbital speed also protects the station from atmospheric drag. Small engine burns are scheduled to counter the thin traces of Earth’s atmosphere that still brush the ISS at its altitude, ensuring it remains high enough to avoid re-entry.',
     explorerFeature: 'orbit-speed',
     facts: ['Speed: 27,571 km/h', '90-minute orbits', '16 sunrises every day'],
+    model: '/models/lesson-orbit-speed.glb',
     visual: 'orbit',
     funFact: 'In the time it takes you to watch a movie, the ISS has circled Earth nearly twice.',
   },
@@ -42,6 +44,7 @@ export const lessonData: Lesson[] = [
       'Because the ISS loops around Earth every 90 minutes, crew members witness daybreak and nightfall many times during a single shift. Each orbit carries the station through alternating arcs of daylight and darkness, resulting in about 16 sunrises and 16 sunsets every 24 hours. The spectacle paints the horizon with vivid colors that race across the windows in mere moments.\n\nThis rapid light cycle can challenge human circadian rhythms. Astronauts rely on carefully programmed lighting inside the station, along with strict sleep schedules, to signal to their bodies when it is time to rest. Mission planners also choreograph activities to minimize fatigue, particularly during spacewalk preparations when alertness is vital.\n\nStudying how the body adapts to these rapid transitions helps scientists design lighting systems and routines for future deep-space missions. Lessons learned from the ISS inform how crews might live on voyages to the Moon, Mars, and beyond.',
     explorerFeature: 'day-night-cycle',
     facts: ['1 orbit = 90 minutes', 'Day/night changes every 45 minutes', 'Lighting helps regulate sleep'],
+    model: '/models/lesson-day-night.glb',
     visual: 'dayNight',
     funFact: 'Astronauts sometimes wear light-blocking visors at “night” so their brains know it is time to sleep.',
   },
@@ -53,6 +56,7 @@ export const lessonData: Lesson[] = [
       'The Cupola module is a seven-window observatory perched on the ISS that provides astronauts with a sweeping panorama of Earth and space. Its central round window is the largest ever flown on a spacecraft, allowing crew members to admire swirling weather systems, glowing city lights, and the thin blue line of Earth’s atmosphere.\n\nBeyond its unmatched view, the Cupola is a functional workstation. Astronauts use it to operate the Canadarm2 robotic arm, monitor visiting spacecraft, and oversee spacewalks. The surrounding equipment consoles glow with instrument readouts, framing Earth’s beauty with the practical tools of orbital operations.\n\nThe Cupola has also become an iconic venue for photography. Images captured here help scientists track natural events like hurricanes, volcanic eruptions, and glacial changes, while inspiring people on Earth with the fragility and wonder of our planet.',
     explorerFeature: 'cupola-view',
     facts: ['Seven-window observation dome', 'Built by the European Space Agency', 'Hosts the Canadarm2 controls'],
+    model: '/models/lesson-cupola.glb',
     visual: 'cupola',
     funFact: 'Astronaut Tracy Caldwell Dyson once spent her off-duty time recording poetry readings from the Cupola.',
   },
@@ -64,6 +68,7 @@ export const lessonData: Lesson[] = [
       'Auroras ignite when charged particles from the Sun stream along Earth’s magnetic field and collide with atoms in the upper atmosphere. From the ISS, astronauts often watch these storms of light ripple beneath them like neon curtains draped over the poles. Greens, purples, and reds shimmer along the horizon, sometimes stretching thousands of kilometers across.\n\nScientists study auroras from orbit to understand how solar activity influences our planet. Observations from the station complement measurements from satellites and ground-based telescopes, offering unique vantage points on the shape and movement of these glowing ribbons.\n\nFor the crew, aurora sightings are a cherished perk of orbital life. Many describe the experience as a reminder of Earth’s delicate shield against the harsh environment of space, reinforcing the importance of monitoring our planet’s magnetic and atmospheric health.',
     explorerFeature: 'aurora',
     facts: ['Caused by solar wind particles', 'Best seen near the poles', 'Colors depend on atmospheric gases'],
+    model: '/models/lesson-aurora.glb',
     visual: 'aurora',
     funFact: 'Some auroras are so bright that astronauts can read checklists by their glow.',
   },
@@ -75,6 +80,7 @@ export const lessonData: Lesson[] = [
       'Astronauts aboard the ISS live in microgravity, where every daily task becomes a challenge. Sleeping requires strapping themselves into sleeping bags so they do not drift around. Meals arrive dehydrated or thermostabilized, and each pouch must be carefully managed so crumbs and droplets do not float away.\n\nTo stay healthy, crew members exercise around two hours each day using treadmills, stationary bikes, and resistive machines. Without this routine, muscles and bones weaken quickly. Astronauts also schedule regular medical checks, coordinate video calls with family, and carve out time for science experiments and maintenance tasks.',
     explorerFeature: 'life-on-iss',
     facts: ['Two hours of exercise daily', 'Sleeping bags attach to walls', 'Food is carefully packaged'],
+    model: '/models/lesson-life-iss.glb',
     visual: 'life',
     funFact: 'Velcro is everywhere aboard the ISS—it keeps pens, utensils, and experiments from floating away.',
   },
@@ -86,6 +92,7 @@ export const lessonData: Lesson[] = [
       'The ISS is constantly falling toward Earth, but its tremendous forward speed means it keeps missing the planet. This balance between gravity’s pull and orbital velocity creates continuous free fall, known as orbit. Astronauts feel weightless because they fall at the same rate as their spacecraft.\n\nControllers perform periodic reboost maneuvers to counter atmospheric drag. These small engine burns nudge the station to higher altitudes, keeping the balance between gravity and speed intact and ensuring the laboratory remains aloft.',
     explorerFeature: 'why-iss-doesnt-fall',
     facts: ['Orbit is continuous free fall', 'Reboost burns fight drag', 'Velocity balances gravity'],
+    model: '/models/lesson-orbit-physics.glb',
     visual: 'orbitPhysics',
     funFact: 'Even at 400 km up, traces of atmosphere still tug on the ISS and gradually slow it down.',
   },
@@ -97,6 +104,7 @@ export const lessonData: Lesson[] = [
       'The ISS is a symbol of global cooperation. NASA, Roscosmos, ESA, JAXA, and CSA built and operate the outpost together, coordinating everything from launch schedules to science programs. Crew members often speak multiple languages to collaborate seamlessly during spacewalks and experiments.\n\nInternational partners share responsibilities for resupply missions, power systems, and research priorities. This teamwork showcases how nations can pool resources to tackle complex challenges in space.',
     explorerFeature: 'international-crew',
     facts: ['15 nations have flown crew', 'Mission control spans continents', 'Shared science goals unite partners'],
+    model: '/models/lesson-international-crew.glb',
     visual: 'international',
     funFact: 'The ISS’s official languages are English and Russian, and every astronaut learns key phrases in both.',
   },
@@ -108,6 +116,7 @@ export const lessonData: Lesson[] = [
       'The ISS enables experiments impossible on Earth. In microgravity, flames form spheres, fluids behave strangely, and biological systems reveal how gravity shapes life. Scientists study everything from crystal growth to human immune responses using the station’s specialized facilities.\n\nResults feed into medicine, materials science, and future exploration. Insights gained in orbit help design lighter alloys, more effective drugs, and life-support systems for deep-space missions.',
     explorerFeature: 'microgravity-experiments',
     facts: ['Microgravity changes fluid behavior', 'Over 3,000 experiments so far', 'Findings improve life on Earth'],
+    model: '/models/lesson-microgravity.glb',
     visual: 'microgravity',
     funFact: 'Protein crystals grown on the ISS can be up to 10 times larger than those made on Earth.',
   },
@@ -119,6 +128,7 @@ export const lessonData: Lesson[] = [
       'From its vantage point, the ISS offers sweeping views of our planet. Astronauts use handheld cameras to capture storms, wildfires, and coastlines in stunning detail. These images support disaster response teams, environmental researchers, and educators around the world.\n\nMounted instruments gather data on atmospheric chemistry, ocean color, and changes in vegetation. Combining human observations with sensor readings provides a richer understanding of Earth’s dynamic systems.',
     explorerFeature: 'earth-observation',
     facts: ['Crew take thousands of photos yearly', 'Instruments monitor climate trends', 'Data assists disaster response'],
+    model: '/models/lesson-earth-observation.glb',
     visual: 'earthObservation',
     funFact: 'Some of the most detailed lightning studies come from cameras pointed out of the ISS windows.',
   },
@@ -130,6 +140,7 @@ export const lessonData: Lesson[] = [
       'The ISS relies on a network of Tracking and Data Relay Satellites (TDRS) to transmit voice, video, and science data. These satellites route signals between the station and ground antennas, ensuring controllers can monitor systems in real time.\n\nAstronauts also benefit from internet-linked services for email, video calls, and live broadcasts. Delays are minimal thanks to the satellite network, keeping the crew connected to loved ones and classrooms.',
     explorerFeature: 'communications',
     facts: ['TDRS network keeps contact continuous', 'Voice, video, and telemetry stream constantly', 'Crew can video chat with family'],
+    model: '/models/lesson-communications.glb',
     visual: 'communications',
     funFact: 'Astronauts occasionally join live TV interviews from orbit using the same communications network.',
   },
@@ -141,6 +152,7 @@ export const lessonData: Lesson[] = [
       'The ISS receives cargo and crew from visiting spacecraft such as SpaceX Dragon, Boeing Starliner, Northrop Grumman Cygnus, and Soyuz. Approaching vehicles follow precise trajectories, guided by GPS, lasers, and crew monitoring from inside the station.\n\nSome spacecraft dock autonomously, while others require manual control using joysticks and cameras. Every arrival brings fresh supplies, experiments, and sometimes new modules.',
     explorerFeature: 'docking',
     facts: ['Multiple spacecraft visit yearly', 'Autonomous and manual dockings occur', 'Cargo delivers experiments and fuel'],
+    model: '/models/lesson-docking.glb',
     visual: 'docking',
     funFact: 'The Canadarm2 robotic arm can capture spacecraft that do not dock on their own, like Northrop Grumman’s Cygnus.',
   },
@@ -152,6 +164,7 @@ export const lessonData: Lesson[] = [
       'The ISS has been in operation since 1998, but its mission is evolving. NASA and its partners plan to transition research to commercial space stations later in the decade, freeing resources for deep-space exploration. Companies are already designing free-flying laboratories and commercial modules.\n\nLessons from the ISS inform the Lunar Gateway, a planned outpost around the Moon that will support Artemis missions. The experience gained in long-duration spaceflight will also prepare crews for eventual voyages to Mars.',
     explorerFeature: 'future-of-iss',
     facts: ['Commercial stations are in development', 'Lunar Gateway builds on ISS lessons', 'ISS operations extend through 2030'],
+    model: '/models/lesson-future-iss.glb',
     visual: 'future',
     funFact: 'Some ISS modules may be detached and reused as part of commercial stations after retirement.',
   },

--- a/src/index.css
+++ b/src/index.css
@@ -79,3 +79,33 @@ a {
 .scrollable-modal::-webkit-scrollbar-thumb:hover {
   background: rgba(0, 200, 255, 0.8);
 }
+
+.lesson-scrollable-content {
+  padding: 1.5rem 2rem;
+  color: #dbe7ff;
+  overflow-y: auto;
+  max-height: calc(100vh - 400px);
+  scrollbar-width: thin;
+  scrollbar-color: rgba(60, 80, 120, 0.6) transparent;
+}
+
+.lesson-scrollable-content::-webkit-scrollbar {
+  width: 6px;
+}
+
+.lesson-scrollable-content::-webkit-scrollbar-thumb {
+  background: rgba(60, 80, 120, 0.6);
+  border-radius: 999px;
+}
+
+.lesson-scrollable-content::-webkit-scrollbar-thumb:hover {
+  background: rgba(129, 161, 255, 0.8);
+}
+
+.fact-item {
+  background: rgba(45, 60, 90, 0.4);
+  padding: 0.5rem 1rem;
+  border-radius: 8px;
+  margin-right: 0.5rem;
+  margin-bottom: 0.5rem;
+}

--- a/src/pages/EducationPage.tsx
+++ b/src/pages/EducationPage.tsx
@@ -285,10 +285,10 @@ const EducationPage = () => {
                   animate="center"
                   exit="exit"
                   custom={navigationDirection}
-                  className="grow overflow-y-auto overscroll-contain scroll-smooth px-6 py-6 space-y-10 modal-scroll"
+                  className="grow overflow-y-auto overscroll-contain scroll-smooth px-6 py-6 space-y-10 modal-scroll lesson-scrollable-content"
                 >
                   <section className="lesson-section">
-                    <LessonVisual visual={selectedLesson.visual} />
+                    <LessonVisual lesson={selectedLesson} />
                   </section>
 
                   <section className="lesson-section grid grid-cols-1 md:grid-cols-2 gap-8">
@@ -301,7 +301,7 @@ const EducationPage = () => {
                       <h3 className="text-sky-300/90 text-sm tracking-widest uppercase mb-3">Key Facts</h3>
                       <ul className="grid gap-3 md:grid-cols-1">
                         {selectedLesson.facts.map((fact) => (
-                          <li key={fact} className="rounded-xl border border-sky-700/40 bg-slate-900/50 px-3 py-2">
+                          <li key={fact} className="fact-item border border-sky-700/40 text-sky-100/90">
                             {fact}
                           </li>
                         ))}


### PR DESCRIPTION
## Summary
- rebuild the lesson visual canvas with React Three Fiber, bloom post-processing, and parallax controls for more cinematic scenes
- add a reusable LessonModel loader that brings in per-lesson GLTF assets with idle animation and hover-responsive scaling
- extend lesson data and styling so each modal surfaces the correct model path and polished scroll/fact styling

## Testing
- npm install three @react-three/fiber @react-three/drei @react-three/postprocessing react-spring *(fails: npm ERR! 403 Forbidden from registry)*

------
https://chatgpt.com/codex/tasks/task_e_68e16ee951108331bd6ecff95289ca33