### PR TITLE
Add start quiz button to lesson cards

### DIFF
--- a/src/pages/EducationPage.tsx
+++ b/src/pages/EducationPage.tsx
@@ -297,6 +297,18 @@ const EducationPage = () => {
                       →
                     </span>
                   </div>
+                  <div className="mt-4 flex justify-end">
+                    <button
+                      type="button"
+                      onClick={(event) => {
+                        event.stopPropagation();
+                        handleLessonSelect(lesson);
+                      }}
+                      className="rounded-xl border border-cyan-400/60 bg-cyan-500/20 px-4 py-2 text-[11px] font-semibold uppercase tracking-[0.35em] text-cyan-100 transition hover:-translate-y-0.5 hover:shadow-[0_20px_60px_-45px_rgba(6,182,212,0.85)] focus-visible:outline focus-visible:outline-2 focus-visible:outline-cyan-300"
+                    >
+                      Start Quiz
+                    </button>
+                  </div>
                 </div>
               </motion.article>
             );


### PR DESCRIPTION
## Summary
- add a clear "Start Quiz" button on each education lesson card so users can launch quizzes directly

## Testing
- npm run build *(fails: missing optional dependencies @react-three/drei, @react-three/postprocessing, @react-spring/three in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e17ce838688331912e6665498eaab4