### PR TITLE
Handle lesson visual loader failures

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,3 +43,7 @@ Visit [http://localhost:5173](http://localhost:5173) once the dev server is runn
 
 - TLE updates are logged in the telemetry panel. In development builds, the console reports any fetch issues and keeps the previous orbital solution active until new data arrives.
 - The Three.js scene logs warnings if shaders or textures fail to load.
+
+## Manual Checks
+
+- **Lesson visual fallback** – With the dev server running, temporarily rename or remove a lesson GLB under `public/models/lessons`. Open the Education modal for the affected lesson and confirm the "Lesson visual unavailable" message appears while the rest of the modal remains usable. Restore the asset afterwards.


### PR DESCRIPTION
## Summary
- add a lesson visual error boundary that catches loader failures and renders the fallback copy
- log loader errors with lesson metadata for diagnostics
- document a manual check to verify the fallback when GLB assets are unavailable

## Testing
- npm run build *(fails: vite not found in sandbox environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e193beed408331aee812cfacdca975