### PR TITLE
Persist challenge history records

### DIFF
--- a/src/utils/storageKeys.ts
+++ b/src/utils/storageKeys.ts
@@ -1,8 +1,10 @@
 export const LESSON_PROGRESS_STORAGE_KEY = 'cupola-education-progress';
-export const CHALLENGE_RANK_STORAGE_KEY = 'cupola-challenge-rank';
+export const CHALLENGE_HISTORY_STORAGE_KEY = 'cupola-challenge-history';
 
 export interface ChallengeRankRecord {
-  rank: 'Bronze' | 'Silver' | 'Gold';
-  percentage: number;
-  completedAt: string;
+  timestamp: string;
+  score: number;
+  rank: string;
+  accuracy: number;
+  timeTaken: number;
 }


### PR DESCRIPTION
## Summary
- replace the single stored challenge record with a persistent history array and updated ChallengeRankRecord schema
- append new challenge results with timestamp, score, accuracy, and time taken while migrating any legacy data
- update the challenge and education pages to surface the latest recorded rank from the history store

## Testing
- npm install *(fails: 403 Forbidden fetching @react-three/drei)*

------
https://chatgpt.com/codex/tasks/task_e_68e199e0dd2c83318cb882a5d863f37d