### PR TITLE
Implement persistent education progress and XP ranks

### DIFF
--- a/src/components/education/LessonModal.tsx
+++ b/src/components/education/LessonModal.tsx
@@ -115,6 +115,7 @@ const LessonModal = ({
             <QuizModule
               key={lesson.id}
               lessonId={lesson.id}
+              lessonTitle={lesson.title}
               questions={quiz.questions}
               onComplete={onQuizComplete}
             />

--- a/src/pages/ChallengePage.tsx
+++ b/src/pages/ChallengePage.tsx
@@ -198,9 +198,11 @@ const ChallengePage = () => {
               <QuizModule
                 key={sessionId}
                 lessonId={0}
+                lessonTitle="ISS Knowledge Challenge"
                 questions={questions}
                 onComplete={handleChallengeComplete}
                 showCompletionModal={false}
+                persistProgress={false}
               />
             </motion.section>
           )}


### PR DESCRIPTION
## Summary
- add rank tiers, XP helpers, and storage retrieval utilities for education progress
- synchronize the quiz module and progress hook with localStorage, track XP gains, and surface personal bests
- overhaul the education dashboard to show XP rank, knowledge stats, and per-lesson progress while preventing challenge runs from altering lesson data

## Testing
- npm install *(fails: registry returned 403 for @react-three/drei)*
- npm run build *(fails: vite executable missing because dependencies were not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68e23cd9b7ec833187d36b6d1fa1d7f6