### PR TITLE
Prevent quiz retakes from clearing completed lessons

### DIFF
--- a/src/utils/educationProgress.ts
+++ b/src/utils/educationProgress.ts
@@ -162,7 +162,7 @@ const mergeLessonProgress = (current: LessonProgress[], incoming: LessonProgress
   incoming.forEach((lesson) => {
     const normalized = normalizeLesson(lesson);
     const existing = map.get(normalized.id);
-    const completed = normalized.completed ?? existing?.completed ?? false;
+    const completed = Boolean(normalized.completed || existing?.completed);
     const completedAt = completed
       ? normalizeDate(normalized.completedAt) ?? existing?.completedAt ?? new Date().toISOString()
       : existing?.completedAt;


### PR DESCRIPTION
## Summary
- keep stored lessons marked complete when a retake submission fails
- ensure completion timestamps remain intact when progress is merged

## Testing
- npm install *(fails: 403 Forbidden fetching @react-three/drei)*

------
https://chatgpt.com/codex/tasks/task_e_68e242d254148331b5eb9f5ac863e54e